### PR TITLE
CSS Fix: prevent extraneous scrollbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # perma-extension
 A browser extension for [Perma.cc](https://perma.cc/). Create and manage Perma links directly from the browser.
 
-- **Current version:** 2.0.0 Beta 🚧
+- **Current version:** 2.0.1
 - **Browsers currently supported:** Google Chrome (100+)
 
 [![Test suite](https://github.com/harvard-lil/perma-extension/actions/workflows/tests.yml/badge.svg)](https://github.com/harvard-lil/perma-extension/actions/workflows/playwright.yml)

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "name": "Perma.cc",
   "description": "__MSG_app_description__",
   "default_locale": "en",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "manifest_version": 3,
   "minimum_chrome_version": "100",
   "icons": {

--- a/src/popup/index.css
+++ b/src/popup/index.css
@@ -56,7 +56,7 @@ html {
 
 body {
   width: var(--extension-width);
-  height: var(--extension-height);
+  height: calc(var(--extension-height) - var(--body-border-width));
   border: var(--body-border-width) solid var(--main-color--);
   background-color: var(--main-color);
   color: var(--opposite-color);


### PR DESCRIPTION
An unnecessary scrollbar may appear alongside the extension, based on OS-level settings regarding scroll bar behavior. This PR accounts for it. 