### PR TITLE
Update Firefox manifest for publication on addons.mozilla.org

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -32,7 +32,8 @@ const transformManifest = (contents, filename) => {
   delete manifest.minimum_chrome_version;
   manifest.browser_specific_settings = {
     gecko: {
-      strict_min_version: "100"
+      id: "firefox@perma.cc",
+      strict_min_version: "112.0"
     }
   };
 
@@ -108,7 +109,7 @@ export default defineConfig({
     sourcemap: true,
     devSourcemap: true,
     minify: false,
-    target: ["chrome100", "firefox100"],
+    target: ["chrome100", "firefox112"],
 
     rollupOptions: {
       input: {


### PR DESCRIPTION
This addresses a few flags that were raised when validating the latest Firefox extension build on [addons.mozilla.org](https://addons.mozilla.org), namely:

* Build must target Firefox 112 at minimum because we use a V3-format extension manifest
* Manifest property `browser_specific_settings.gecko.strict_min_version` must include minor version (`112.0`, not `112`)
* Manifest must include our existing Firefox extension ID (`firefox@perma.cc`)