### PR TITLE
Update extension API usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,7 @@
+# staff can pull this from "op://LIL Staff/perma-js-sdk-test-user/API_KEY"
 TESTS_API_KEY="abcedfghijklmnopqrstuvwxyz12345678901234"
+# TESTS_API_ALLOW_NON_TEST_USER=1
+
+# Firefox binary used by `just dev firefox`. Leave unset to let web-ext find firefox on PATH; set it
+# if you run a non-standard build, e.g. Firefox Developer Edition on macOS:
+# FIREFOX_BIN="/Applications/Firefox Developer Edition.app/Contents/MacOS/firefox"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '18.x'
+        node-version: '22.x'
 
     - name: Install dependencies
       run: npm install

--- a/README.md
+++ b/README.md
@@ -55,12 +55,14 @@ flowchart RL
 
 ### Getting started
 
-- Make sure you have [the latest version of Node.js](https://nodejs.org/en/) installed on your machine _(18+ recommended)_.
-- Run `npm install` to install dependencies.
-- Use `npm run dev` to start _"development"_ mode. This effectively starts `vite build --watch`, creating a new build under `/dist` every time a file changes.
-  + Note: when developing for Mozilla Firefox, you must set the environment variable `TARGET=firefox` prior to executing `npm run dev`.
+- Make sure you have [the latest version of Node.js](https://nodejs.org/en/) installed on your machine _(Vite 8 requires Node 20.19+ or 22.12+; 22+ recommended)_, along with [`just`](https://github.com/casey/just) for running project tasks.
+- Run `just setup` to install dependencies (npm packages + the Chromium build Playwright uses for tests).
+- Use `just dev` to build the extension and launch it in a browser with the extension preloaded, auto-reloading on every source change. Use `just dev firefox` to do the same in Firefox.
+  + If you only want a rebuild-on-change loop without launching a browser, use `just watch` (or `just watch firefox`).
 
 ### Install the work-in-progress extension
+
+If you'd rather load the build into your own browser manually instead of using `just dev`:
 
 #### Google Chrome
 
@@ -86,12 +88,15 @@ flowchart RL
 
 ### Scope: E2E testing
 
-The following environment variables are only used in the context of [the test suites](#testing). They may be provided using an `.env` file, which the Playwright test runner will take into account.
+The following environment variables are only used in the context of [the test suites](#testing). They may be provided using an `.env` file, which both `just` and the Playwright test runner load.
 
 | Name | Context | Required | Description |
 | --- | --- | --- | --- |
-| `TESTS_API_KEY` | Test suite | Yes | API key to be used for E2E tests. |
+| `TESTS_API_KEY` | Test suite | Yes | API key to be used for E2E tests. Must belong to `perma-js-sdk-test-user` unless `TESTS_API_ALLOW_NON_TEST_USER=1` is set. |
+| `TESTS_API_ALLOW_NON_TEST_USER` | Test suite | No | Set to `"1"` only when intentionally running live API tests with a non-test account. |
 | `CI` | Test suite | No | Will alter test reporting if set _(see `playwright.config.js`)_. Used to run tests in a GitHub Action. |
+| `HEADLESS` | Test suite | No | Defaults to headless (Chromium's new headless mode, which loads the extension). Set to `"false"` to watch the browser; with `just`, run `just headful=1 test`. |
+| `FIREFOX_BIN` | Dev (`just dev firefox`) | No | Path to the Firefox binary web-ext should launch. Leave unset to use `firefox` on `PATH`; set it for a non-standard build like Firefox Developer Edition. |
 
 ### Scope: Building the extension
 
@@ -155,45 +160,87 @@ Automatically-generated API documentation. Uses [JSDoc](https://jsdoc.app/) comm
 
 ## CLI
 
-### dev
+Project tasks are run with [`just`](https://github.com/casey/just). Run `just` (or `just --list`) to see every recipe. Browser-specific recipes take a `target` argument (`chrome` or `firefox`) that defaults to `chrome` — e.g. `just build` builds for Chrome, `just build firefox` for Firefox.
 
-```
-npm run dev
+### setup
+
+```bash
+just setup
 ```
 
-Starts _"development"_ mode.  Effectively runs `vite build --watch`, creating a new build under `/dist` every time a file changes.
+Installs dependencies: npm packages + the Chromium build used by the test suite.
 
 ### build
 
-```
-npm run build
-```
-
-Generates a new extension build under `/dist`.
-
-### build-and-zip
-
-```
-npm run build-and-zip
+```bash
+just build          # or: just build firefox
 ```
 
-Generates a new extension build under `/dist` and generates a zip from it _(`perma-extension.zip`)_.
+Generates a new extension build under `/dist` for the target browser.
 
-### docgen
+### dev
 
 ```bash
-npm run docgen
+just dev            # or: just dev firefox
 ```
 
-Generates documentation using [`JSDoc` comments](https://jsdoc.app/). Outputs as Markdown to `doc`. To update which files should be taken into account, check `/scripts/docgen.sh`.
+Builds the target variant and launches it in a browser via web-ext, with the extension preloaded and auto-reloading on every source change. For Firefox, set `FIREFOX_BIN` in `.env` if you use a non-standard build (e.g. Developer Edition).
+
+### watch
+
+```bash
+just watch          # or: just watch firefox
+```
+
+Rebuilds into `/dist` on every source change, without launching a browser.
 
 ### test
 
 ```bash
-npm run test
+just test           # or: just headful=1 test  (to watch the browser)
 ```
 
-Runs the end-to-end tests suite using [playwright](https://playwright.dev/).
+Runs the end-to-end test suite using [Playwright](https://playwright.dev/). Headless by default; the scenario specs require a live `TESTS_API_KEY`.
+
+### test-components
+
+```bash
+just test-components
+```
+
+Runs only the self-contained component tests (no API key required).
+
+### lint
+
+```bash
+just lint           # or: just lint firefox
+```
+
+Lints the built extension with web-ext (validates the manifest, etc.).
+
+### package
+
+```bash
+just package        # or: just package firefox
+```
+
+Builds the target variant and packages `/dist` into `perma-extension-<target>.zip` for distribution.
+
+### docs
+
+```bash
+just docs
+```
+
+Generates documentation using [`JSDoc` comments](https://jsdoc.app/). Outputs as Markdown to `doc`. To update which files should be taken into account, check `/scripts/docgen.sh`.
+
+### clean
+
+```bash
+just clean
+```
+
+Removes build output (`dist/` and any `perma-extension*.zip`).
 
 [☝️ Back to summary](#summary)
 
@@ -201,11 +248,11 @@ Runs the end-to-end tests suite using [playwright](https://playwright.dev/).
 
 ## Building and distributing the extension
 
-Note: to build for Mozilla Firefox, you must set the environment variable `TARGET=firefox` when executing the following steps.
+Note: to build for Mozilla Firefox, pass the `firefox` target to the `just` recipes below (e.g. `just package firefox`).
 
 **Step-by-step**:
 - On `develop`:
-  - Update documentation (`npm run docgen`)
+  - Update documentation (`just docs`)
   - Update version number in:
     - [`manifest.json`](https://github.com/harvard-lil/perma-extension/blob/develop/src/manifest.json#L5)
     - This README
@@ -216,9 +263,9 @@ Note: to build for Mozilla Firefox, you must set the environment variable `TARGE
       - Using the `main` branch
       - Using [semver](https://semver.org/) as a title and tag _(i.e: `2.0.1`)_
   - Locally:
-    - Run `npm run build-and-zip` to generate `perma-extension.zip`.
+    - Run `just package` to generate `perma-extension-chrome.zip` (or `just package firefox` for `perma-extension-firefox.zip`).
 - On the [Chrome Web Store](https://chrome.google.com/webstore/category/extensions) or [Add-ons for Firefox](https://addons.mozilla.org/en-US/firefox/)
-  - Upload `perma-extension.zip`
+  - Upload the generated `.zip`
 
 [☝️ Back to summary](#summary)
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,66 @@
+# perma-extension — common project tasks.
+# Run `just` (or `just --list`) to see all recipes.
+#
+# Every browser-specific recipe takes a `target` argument ("chrome" or "firefox") and defaults
+# to chrome. The extension is built per-browser: `src/manifest.json` is shared and transformed at
+# build time (see vite.config.js). TARGET=firefox swaps the Chrome MV3 `background.service_worker`
+# for Firefox's `background.scripts` and adds the gecko settings; anything else builds the Chrome
+# variant. So `dist/` only ever holds ONE browser's build — rebuild when you switch browsers.
+
+# Load .env so recipes and the build see the same vars the test/build configs read via dotenv.
+set dotenv-load := true
+
+# Tests run headless by default. Set headful=1 to watch the browser: `just headful=1 test`.
+headful := ""
+
+# List available recipes (default when you run bare `just`).
+default:
+    @just --list
+
+# Install dependencies: npm packages + Playwright's Chromium (needed by the test suite).
+setup:
+    npm install
+    npx playwright install chromium
+
+# Build the extension into dist/ for a target browser ("chrome" or "firefox").
+build target="chrome":
+    TARGET={{target}} npm run build
+
+# Build a target variant, then launch it via web-ext (auto-reloads on source change).
+# For firefox, set FIREFOX_BIN in .env (Developer Edition is at a non-standard path); empty = PATH.
+dev target="chrome": (build target)
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ "{{target}}" = "firefox" ]; then
+        npx web-ext run --source-dir dist --devtools ${FIREFOX_BIN:+--firefox="$FIREFOX_BIN"}
+    else
+        npx web-ext run --source-dir dist --target chromium
+    fi
+
+# Rebuild on every source change for a target browser.
+watch target="chrome":
+    TARGET={{target}} npm run dev
+
+# Run the full Playwright suite for a target build. Scenario specs need a live TESTS_API_KEY.
+test: (build "chrome")
+    HEADLESS={{ if headful == "" { "true" } else { "false" } }} npx playwright test
+
+# Run only the self-contained component tests (no API key required).
+test-components target="chrome": (build target)
+    HEADLESS={{ if headful == "" { "true" } else { "false" } }} npx playwright test tests/components
+
+# Lint the built extension with web-ext (validates the manifest, etc.) for a target browser.
+lint target="chrome": (build target)
+    npx web-ext lint --source-dir dist
+
+# Build a target variant and package dist/ into perma-extension-<target>.zip for distribution.
+package target="chrome": (build target)
+    cd dist && zip -r ../perma-extension-{{target}}.zip *
+
+# Generate documentation.
+docs:
+    npm run docgen
+
+# Remove build output.
+clean:
+    rm -rf dist perma-extension*.zip

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,20 +11,44 @@
         "@harvard-lil/perma-js-sdk": "^0.0.5"
       },
       "devDependencies": {
-        "@playwright/test": "^1.23.4",
-        "@types/chrome": "^0.0.190",
-        "dotenv": "^16.0.1",
-        "jsdoc-to-markdown": "^7.1.1",
-        "prettier": "^2.6.2",
-        "vite": "^6.1.0",
-        "vite-plugin-static-copy": "^2.2.0"
+        "@playwright/test": "^1.60.0",
+        "@types/chrome": "^0.1.43",
+        "dotenv": "^17.4.2",
+        "jsdoc-to-markdown": "^9.1.3",
+        "prettier": "^3.8.3",
+        "vite": "^8.0.16",
+        "vite-plugin-static-copy": "^4.1.1"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.4.tgz",
-      "integrity": "sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -32,429 +56,52 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
-      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
       "engines": {
-        "node": ">=18"
+        "node": ">=6.9.0"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
-      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
-      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
-      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
-      "cpu": [
-        "x64"
-      ],
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
-      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
-      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
-      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
-      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
-      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
-      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
-      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
-      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
-      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
-      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
-      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
-      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
-      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
-      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
-      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
-      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@harvard-lil/perma-js-sdk": {
@@ -464,15 +111,35 @@
       "license": "MIT"
     },
     "node_modules/@jsdoc/salty": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.5.tgz",
-      "integrity": "sha512-TfRP53RqunNe2HBobVBJ0VLhK1HbfvBYeTC1ahnN64PWvyYyGebmMiPkuwvD9fpw2ZbkoPb8Q7mwy0aR8Z9rvw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.12.tgz",
+      "integrity": "sha512-TuB0x50EoAvEX/UEWITd8Mkn3WhiTjSvbTMCLj0BhsQEl5iUzjXdA0bETEVpTk+5TGTLR6QktI9H4hLviVeaAQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "lodash": "^4.17.21"
+        "lodash": "^4.18.1"
       },
       "engines": {
         "node": ">=v12.0.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -480,6 +147,7 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -493,6 +161,7 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -502,6 +171,7 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -510,40 +180,36 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@playwright/test": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.23.4.tgz",
-      "integrity": "sha512-iIsoMJDS/lyuhw82FtcV/B3PXikgVD3hNe5hyvOpRM0uRr1OIpN3LgPeRbBjhzBWmyf6RgRg5fqK5sVcpA03yA==",
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@types/node": "*",
-        "playwright-core": "1.23.4"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.6.tgz",
-      "integrity": "sha512-+GcCXtOQoWuC7hhX1P00LqjjIiS/iOouHXhMdiDSnq/1DGTox4SpUvO52Xm+div6+106r+TcvOeo/cxvyEyTgg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.6.tgz",
-      "integrity": "sha512-E8+2qCIjciYUnCa1AiVF1BkRgqIGW9KzJeesQqVfyRITGQN+dFuoivO0hnro1DjT74wXLRZ7QF8MIbz+luGaJA==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -552,12 +218,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.6.tgz",
-      "integrity": "sha512-z9Ib+OzqN3DZEjX7PDQMHEhtF+t6Mi2z/ueChQPLS/qUMKY7Ybn5A2ggFoKRNRh1q1T03YTQfBTQCJZiepESAg==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -566,12 +235,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.6.tgz",
-      "integrity": "sha512-PShKVY4u0FDAR7jskyFIYVyHEPCPnIQY8s5OcXkdU8mz3Y7eXDJPdyM/ZWjkYdR2m0izD9HHWA8sGcXn+Qrsyg==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -580,26 +252,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.6.tgz",
-      "integrity": "sha512-YSwyOqlDAdKqs0iKuqvRHLN4SrD2TiswfoLfvYXseKbL47ht1grQpq46MSiQAx6rQEN8o8URtpXARCpqabqxGQ==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.6.tgz",
-      "integrity": "sha512-HEP4CgPAY1RxXwwL5sPFv6BBM3tVeLnshF03HMhJYCNc6kvSqBgTMmsEjb72RkZBAWIqiPUyF1JpEBv5XT9wKQ==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -608,12 +269,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.6.tgz",
-      "integrity": "sha512-88fSzjC5xeH9S2Vg3rPgXJULkHcLYMkh8faix8DX4h4TIAL65ekwuQMA/g2CXq8W+NJC43V6fUpYZNjaX3+IIg==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -622,138 +286,171 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.6.tgz",
-      "integrity": "sha512-wM4ztnutBqYFyvNeR7Av+reWI/enK9tDOTKNF+6Kk2Q96k9bwhDDOlnCUNRPvromlVXo04riSliMBs/Z7RteEg==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.6.tgz",
-      "integrity": "sha512-9RyprECbRa9zEjXLtvvshhw4CMrRa3K+0wcp3KME0zmBe1ILmvcVHnypZ/aIDXpRyfhSYSuN4EPdCCj5Du8FIA==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.6.tgz",
-      "integrity": "sha512-qTmklhCTyaJSB05S+iSovfo++EwnIEZxHkzv5dep4qoszUMX5Ca4WM4zAVUMbfdviLgCSQOu5oU8YoGk1s6M9Q==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.6.tgz",
-      "integrity": "sha512-4Qmkaps9yqmpjY5pvpkfOerYgKNUGzQpFxV6rnS7c/JfYbDSU0y6WpbbredB5cCpLFGJEqYX40WUmxMkwhWCjw==",
-      "cpu": [
-        "loong64"
+      "libc": [
+        "musl"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.6.tgz",
-      "integrity": "sha512-Zsrtux3PuaxuBTX/zHdLaFmcofWGzaWW1scwLU3ZbW/X+hSsFbz9wDIp6XvnT7pzYRl9MezWqEqKy7ssmDEnuQ==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.6.tgz",
-      "integrity": "sha512-aK+Zp+CRM55iPrlyKiU3/zyhgzWBxLVrw2mwiQSYJRobCURb781+XstzvA8Gkjg/hbdQFuDw44aUOxVQFycrAg==",
-      "cpu": [
-        "riscv64"
+      "libc": [
+        "glibc"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.6.tgz",
-      "integrity": "sha512-WoKLVrY9ogmaYPXwTH326+ErlCIgMmsoRSx6bO+l68YgJnlOXhygDYSZe/qbUJCSiCiZAQ+tKm88NcWuUXqOzw==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.6.tgz",
-      "integrity": "sha512-Sht4aFvmA4ToHd2vFzwMFaQCiYm2lDFho5rPcvPBT5pCdC+GwHG6CMch4GQfmWTQ1SwRKS0dhDYb54khSrjDWw==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
       ],
       "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
-        "linux"
-      ]
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.6.tgz",
-      "integrity": "sha512-zmmpOQh8vXc2QITsnCiODCDGXFC8LMi64+/oPpPx5qz3pqv0s6x46ps4xoycfUiVZps5PFn1gksZzo4RGTKT+A==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
-        "x64"
+        "wasm32"
       ],
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.6.tgz",
-      "integrity": "sha512-3/q1qUsO/tLqGBaD4uXsB6coVGB3usxw3qyeVb59aArCgedSF66MPdgRStUd7vbZOsko/CgVaY5fo2vkvPLWiA==",
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -762,26 +459,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.6.tgz",
-      "integrity": "sha512-oLHxuyywc6efdKVTxvc0135zPrRdtYVjtVD5GUm55I3ODxhU/PwkQFD97z16Xzxa1Fz0AEe4W/2hzRtd+IfpOA==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.6.tgz",
-      "integrity": "sha512-0PVwmgzZ8+TZ9oGBmdZoQVXflbvuwzN/HRclujpl4N/q3i+y0lqLw8n1bXA8ru3sApDjlmONaNAuYr38y1Kr9w==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -790,24 +476,39 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/chrome": {
-      "version": "0.0.190",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.190.tgz",
-      "integrity": "sha512-lCwwIBfaD+PhG62qFB46mIBpD+xBIa+PedNB24KR9YnmJ0Zn9h0OwP1NQBhI8Cbu1rKwTQHTxhs7GhWGyUvinw==",
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.43.tgz",
+      "integrity": "sha512-ukH/HhmR6ht+UTX3PLUWJxgJ/RQcK2Foj4lBzsF24SIWsXgqhGuXqjd8FFuwioPP7d/JUKLM4g8GZxw3F4HTcA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/filesystem": "*",
         "@types/har-format": "*"
       }
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/filesystem": {
       "version": "0.0.32",
@@ -831,59 +532,52 @@
       "dev": true
     },
     "node_modules/@types/linkify-it": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
-      "dev": true
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
-      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/linkify-it": "*",
-        "@types/mdurl": "*"
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
       }
     },
     "node_modules/@types/mdurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
-      "dev": true
-    },
-    "node_modules/@types/node": {
-      "version": "18.0.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
-      "integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==",
-      "dev": true
-    },
-    "node_modules/ansi-escape-sequences": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.1.0.tgz",
-      "integrity": "sha512-dzW9kHxH011uBsidTXd14JXgzye/YLb2LzeKZ4bsgl/Knwx8AtbSFkkGxagdNOoh0DlqHCmfiEjWKBaqjOanVw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array-back": "^3.0.1"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/ansi-escape-sequences/node_modules/array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -896,47 +590,38 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/array-back": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
-      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.17"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
     "node_modules/binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "dev": true
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
+      "license": "MIT"
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -952,26 +637,24 @@
       }
     },
     "node_modules/cache-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-2.0.0.tgz",
-      "integrity": "sha512-4gkeHlFpSKgm3vm2gJN5sPqfmijYRFYCQ6tv5cLw0xVmT6r1z1vd4FNnpuOREco3cBs1G709sZ72LdgddKvL5w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-3.0.1.tgz",
+      "integrity": "sha512-itTIMLEKbh6Dw5DruXbxAgcyLnh/oPGVLBfTPqBOftASxHe8bAeXy7JkO4F0LvHqht7XqP5O/09h5UcHS2w0FA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array-back": "^4.0.1",
-        "fs-then-native": "^2.0.0",
-        "mkdirp2": "^1.0.4"
+        "array-back": "^6.2.2"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cache-point/node_modules/array-back": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
+        "node": ">=12.17"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
       }
     },
     "node_modules/catharsis": {
@@ -979,6 +662,7 @@
       "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
       "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.15"
       },
@@ -986,17 +670,45 @@
         "node": ">= 10"
       }
     },
-    "node_modules/chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -1009,125 +721,82 @@
       "engines": {
         "node": ">= 8.10.0"
       },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/collect-all": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.4.tgz",
-      "integrity": "sha512-RKZhRwJtJEP5FWul+gkSMEnaK6H3AGPTTWOiRimCcs+rc/OmQE3Yhy1Q7A7KsdkG3ZXVdZq68Y6ONSdvkeEcKA==",
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "stream-connect": "^1.0.2",
-        "stream-via": "^1.0.4"
+        "color-name": "~1.1.4"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=7.0.0"
       }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/command-line-args": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
-      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
+      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array-back": "^3.1.0",
-        "find-replace": "^3.0.0",
+        "array-back": "^6.2.3",
+        "find-replace": "^5.0.2",
         "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
+        "typical": "^7.3.0"
       },
       "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/command-line-args/node_modules/array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/command-line-args/node_modules/typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/command-line-tool": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.8.0.tgz",
-      "integrity": "sha512-Xw18HVx/QzQV3Sc5k1vy3kgtOeGmsKIqwtFFoyjI4bbcpSgnw2CWVULvtakyw4s6fhyAdI6soQQhXc2OzJy62g==",
-      "dev": true,
-      "dependencies": {
-        "ansi-escape-sequences": "^4.0.0",
-        "array-back": "^2.0.0",
-        "command-line-args": "^5.0.0",
-        "command-line-usage": "^4.1.0",
-        "typical": "^2.6.1"
+        "node": ">=12.20"
       },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/command-line-tool/node_modules/array-back": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-      "dev": true,
-      "dependencies": {
-        "typical": "^2.6.1"
+      "peerDependencies": {
+        "@75lb/nature": "latest"
       },
-      "engines": {
-        "node": ">=4"
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
       }
     },
     "node_modules/command-line-usage": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
-      "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-escape-sequences": "^4.0.0",
-        "array-back": "^2.0.0",
-        "table-layout": "^0.4.2",
-        "typical": "^2.6.1"
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
       },
       "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/array-back": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-      "dev": true,
-      "dependencies": {
-        "typical": "^2.6.1"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">=12.20.0"
       }
     },
     "node_modules/common-sequence": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-2.0.2.tgz",
-      "integrity": "sha512-jAg09gkdkrDO9EWTdXfv80WWH3yeZl5oT69fGfedBNS9pXUKYInVJ1bJ+/ht2+Moeei48TmSbQDYMc8EOx9G0g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-3.0.0.tgz",
+      "integrity": "sha512-g/CgSYk93y+a1IKm50tKl7kaT/OjjTYVQlEbUlt/49ZLV1mcKpUU7iyDiqTAeLdb4QDtQfq3ako8y8v//fzrWQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=12.17"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
     },
     "node_modules/config-master": {
       "version": "3.1.0",
@@ -1147,95 +816,77 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+    "node_modules/current-module-paths": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/current-module-paths/-/current-module-paths-1.1.3.tgz",
+      "integrity": "sha512-7AH+ZTRKikdK4s1RmY0l6067UD/NZc7p3zZVZxvmnH80G31kr0y0W0E6ibYM4IS01MEm8DiC5FnTcgcgkbFHoA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dmd": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/dmd/-/dmd-6.1.0.tgz",
-      "integrity": "sha512-0zQIJ873gay1scCTFZvHPWM9mVJBnaylB2NQDI8O9u8O32m00Jb6uxDKexZm8hjTRM7RiWe0FJ32pExHoXdwoQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-7.1.1.tgz",
+      "integrity": "sha512-Ap2HP6iuOek7eShReDLr9jluNJm9RMZESlt29H/Xs1qrVMkcS9X6m5h1mBC56WMxNiSo0wvjGICmZlYUSFjwZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^6.2.2",
-        "cache-point": "^2.0.0",
-        "common-sequence": "^2.0.2",
-        "file-set": "^4.0.2",
-        "handlebars": "^4.7.7",
-        "marked": "^4.0.12",
-        "object-get": "^2.1.1",
-        "reduce-flatten": "^3.0.1",
-        "reduce-unique": "^2.0.1",
-        "reduce-without": "^1.0.1",
-        "test-value": "^3.0.0",
-        "walk-back": "^5.1.0"
+        "cache-point": "^3.0.0",
+        "common-sequence": "^3.0.0",
+        "file-set": "^5.2.2",
+        "handlebars": "^4.7.8",
+        "marked": "^4.3.0",
+        "walk-back": "^5.1.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=12.17"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
       }
     },
     "node_modules/dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/esbuild": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
-      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.24.2",
-        "@esbuild/android-arm": "0.24.2",
-        "@esbuild/android-arm64": "0.24.2",
-        "@esbuild/android-x64": "0.24.2",
-        "@esbuild/darwin-arm64": "0.24.2",
-        "@esbuild/darwin-x64": "0.24.2",
-        "@esbuild/freebsd-arm64": "0.24.2",
-        "@esbuild/freebsd-x64": "0.24.2",
-        "@esbuild/linux-arm": "0.24.2",
-        "@esbuild/linux-arm64": "0.24.2",
-        "@esbuild/linux-ia32": "0.24.2",
-        "@esbuild/linux-loong64": "0.24.2",
-        "@esbuild/linux-mips64el": "0.24.2",
-        "@esbuild/linux-ppc64": "0.24.2",
-        "@esbuild/linux-riscv64": "0.24.2",
-        "@esbuild/linux-s390x": "0.24.2",
-        "@esbuild/linux-x64": "0.24.2",
-        "@esbuild/netbsd-arm64": "0.24.2",
-        "@esbuild/netbsd-x64": "0.24.2",
-        "@esbuild/openbsd-arm64": "0.24.2",
-        "@esbuild/openbsd-x64": "0.24.2",
-        "@esbuild/sunos-x64": "0.24.2",
-        "@esbuild/win32-arm64": "0.24.2",
-        "@esbuild/win32-ia32": "0.24.2",
-        "@esbuild/win32-x64": "0.24.2"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -1243,55 +894,58 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
       }
     },
     "node_modules/fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
       }
     },
     "node_modules/file-set": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/file-set/-/file-set-4.0.2.tgz",
-      "integrity": "sha512-fuxEgzk4L8waGXaAkd8cMr73Pm0FxOVkn8hztzUW7BAHhOGH90viQNXbiOsnecCWmfInqU6YmAMwxRMdKETceQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/file-set/-/file-set-5.3.0.tgz",
+      "integrity": "sha512-FKCxdjLX0J6zqTWdT0RXIxNF/n7MyXXnsSUp0syLEOCKdexvPZ02lNNv2a+gpK9E3hzUYF3+eFZe32ci7goNUg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array-back": "^5.0.0",
-        "glob": "^7.1.6"
+        "array-back": "^6.2.2",
+        "fast-glob": "^3.3.2"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/file-set/node_modules/array-back": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-5.0.0.tgz",
-      "integrity": "sha512-kgVWwJReZWmVuWOQKEOohXKJX+nD02JAZ54D1RRWlv8L0NebauKAaFxACKzB74RTclt1+WNz5KHaLRDAPZbDEw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
+        "node": ">=12.17"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
       }
     },
     "node_modules/fill-range": {
@@ -1308,55 +962,22 @@
       }
     },
     "node_modules/find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "dev": true,
-      "dependencies": {
-        "array-back": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/find-replace/node_modules/array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
+      "engines": {
+        "node": ">=14"
       },
-      "engines": {
-        "node": ">=14.14"
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
       }
-    },
-    "node_modules/fs-then-native": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz",
-      "integrity": "sha512-X712jAOaWXkemQCAmWeg5rOT2i+KOpWz1Z/txk/cW0qlOu2oQ9H61vc5w3X/iyuUEfq/OyaFJ78/cZAQD1/bgA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1373,31 +994,12 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -1406,19 +1008,21 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
         "wordwrap": "^1.0.0"
       },
@@ -1432,27 +1036,22 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -1465,6 +1064,7 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1474,6 +1074,7 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -1496,26 +1097,28 @@
       "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
       "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "xmlcreate": "^2.0.4"
       }
     },
     "node_modules/jsdoc": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.2.tgz",
-      "integrity": "sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.5.tgz",
+      "integrity": "sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "^7.20.15",
         "@jsdoc/salty": "^0.2.1",
-        "@types/markdown-it": "^12.2.3",
+        "@types/markdown-it": "^14.1.1",
         "bluebird": "^3.7.2",
         "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.2",
         "klaw": "^3.0.0",
-        "markdown-it": "^12.3.2",
-        "markdown-it-anchor": "^8.4.1",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^8.6.7",
         "marked": "^4.0.10",
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
@@ -1530,49 +1133,22 @@
       }
     },
     "node_modules/jsdoc-api": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-7.2.0.tgz",
-      "integrity": "sha512-93YDnlm/OYTlLOFeNs4qAv0RBCJ0kGj67xQaWy8wrbk97Rw1EySitoOTHsTHXPEs3uyx2IStPKGrbE7LTnZXbA==",
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-9.3.6.tgz",
+      "integrity": "sha512-8JW0532+rXVw8LoZ1LIAeKofsV8QQZhnY3chxMHV9hQdsuDTshsajwk0b4EMxCqen2vZ2op/r/qeEsqZxsEQyg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array-back": "^6.2.2",
-        "cache-point": "^2.0.0",
-        "collect-all": "^1.0.4",
-        "file-set": "^4.0.2",
-        "fs-then-native": "^2.0.0",
-        "jsdoc": "^4.0.0",
+        "array-back": "^6.2.3",
+        "cache-point": "^3.0.1",
+        "current-module-paths": "^1.1.3",
+        "file-set": "^5.3.0",
+        "jsdoc": "^4.0.5",
         "object-to-spawn-args": "^2.0.1",
-        "temp-path": "^1.0.0",
-        "walk-back": "^5.1.0"
+        "walk-back": "^5.1.2"
       },
       "engines": {
         "node": ">=12.17"
-      }
-    },
-    "node_modules/jsdoc-parse": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.2.4.tgz",
-      "integrity": "sha512-MQA+lCe3ioZd0uGbyB3nDCDZcKgKC7m/Ivt0LgKZdUoOlMJxUWJQ3WI6GeyHp9ouznKaCjlp7CU9sw5k46yZTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^6.2.2",
-        "find-replace": "^5.0.1",
-        "lodash.omit": "^4.5.0",
-        "sort-array": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/jsdoc-parse/node_modules/find-replace": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
-      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       },
       "peerDependencies": {
         "@75lb/nature": "latest"
@@ -1583,38 +1159,50 @@
         }
       }
     },
-    "node_modules/jsdoc-to-markdown": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-7.1.1.tgz",
-      "integrity": "sha512-CI86d63xAVNO+ENumWwmJ034lYe5iGU5GwjtTA11EuphP9tpnoi4hrKgR/J8uME0D+o4KUpVfwX1fjZhc8dEtg==",
+    "node_modules/jsdoc-parse": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.2.5.tgz",
+      "integrity": "sha512-8JaSNjPLr2IuEY4Das1KM6Z4oLHZYUnjRrr27hKSa78Cj0i5Lur3DzNnCkz+DfrKBDoljGMoWOiBVQbtUZJBPw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^6.2.2",
-        "command-line-tool": "^0.8.0",
+        "find-replace": "^5.0.1",
+        "sort-array": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdoc-to-markdown": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-9.1.3.tgz",
+      "integrity": "sha512-i9wi+6WHX0WKziv0ar88T8h7OmxA0LWdQaV23nY6uQyKvdUPzVt0o6YAaOceFuKRF5Rvlju5w/KnZBfdpDAlnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "command-line-args": "^6.0.1",
+        "command-line-usage": "^7.0.3",
         "config-master": "^3.1.0",
-        "dmd": "^6.1.0",
-        "jsdoc-api": "^7.1.1",
-        "jsdoc-parse": "^6.1.0",
-        "walk-back": "^5.1.0"
+        "dmd": "^7.1.1",
+        "jsdoc-api": "^9.3.5",
+        "jsdoc-parse": "^6.2.5",
+        "walk-back": "^5.1.1"
       },
       "bin": {
         "jsdoc2md": "bin/cli.js"
       },
       "engines": {
         "node": ">=12.17"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
       },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
       }
     },
     "node_modules/klaw": {
@@ -1622,57 +1210,344 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
       "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.9"
       }
     },
-    "node_modules/linkify-it": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
-        "uc.micro": "^1.0.1"
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true
-    },
-    "node_modules/lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
-      "dev": true
-    },
-    "node_modules/lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha512-sOQs2aqGpbl27tmCS1QNZA09Uqp01ZzWfDUoD+xzTii0E7dSQfRKcRetFwa+uXaxaqL+TKm7CgD2JdKP7aZBSw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/markdown-it": {
-      "version": "12.3.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
       },
       "bin": {
-        "markdown-it": "bin/markdown-it.js"
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/markdown-it-anchor": {
@@ -1680,16 +1555,18 @@
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
       "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
       "dev": true,
+      "license": "Unlicense",
       "peerDependencies": {
         "@types/markdown-it": "*",
         "markdown-it": "*"
       }
     },
     "node_modules/marked": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
-      "integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -1698,16 +1575,18 @@
       }
     },
     "node_modules/mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -1726,29 +1605,22 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -1756,16 +1628,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/mkdirp2": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.5.tgz",
-      "integrity": "sha512-xOE9xbICroUDmG1ye2h4bZ8WBie9EGmACaco8K8cx6RlkJJrxGIqjGqztAI+NMhexXBcdGbSEzI6N3EJPevxZw==",
-      "dev": true
-    },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -1785,48 +1651,40 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/object-get": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.1.tgz",
-      "integrity": "sha512-7n4IpLMzGGcLEMiQKsNR7vCe+N5E9LORFrtNUVy4sO3dj9a3HedZCxEL2T7QuLhcHN1NBuBsMOKaOsAYI9IIvg==",
-      "dev": true
     },
     "node_modules/object-to-spawn-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-2.0.1.tgz",
       "integrity": "sha512-6FuKFQ39cOID+BMZ3QaphcC8Y4cw6LXBLyIgPU+OhIYwviJamPAn+4mITapnSBQrejB+NNp+FMskhD8Cq+Ys3w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+    "node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "dev": true,
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/picocolors": {
@@ -1837,10 +1695,11 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -1848,22 +1707,57 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/playwright-core": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.4.tgz",
-      "integrity": "sha512-h5V2yw7d8xIwotjyNrkLF13nV9RiiZLHdXeHo+nVJIYGVlZ8U2qV0pMxNJKNTvfQVT0N8/A4CW6/4EW2cOcTiA==",
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.2.tgz",
-      "integrity": "sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -1881,7 +1775,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1890,18 +1784,29 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/queue-microtask": {
@@ -1922,13 +1827,15 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -1936,117 +1843,59 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/reduce-flatten": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-3.0.1.tgz",
-      "integrity": "sha512-bYo+97BmUUOzg09XwfkwALt4PQH1M5L0wzKerBt6WLm3Fhdd43mMS89HiT1B9pJIqko/6lWx3OnV4J9f2Kqp5Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/reduce-unique": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-2.0.1.tgz",
-      "integrity": "sha512-x4jH/8L1eyZGR785WY+ePtyMNhycl1N2XOLxhCbzZFaqF4AXjLzqSxa2UHgJ2ZVR/HHyPOvl1L7xRnW8ye5MdA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/reduce-without": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
-      "integrity": "sha512-zQv5y/cf85sxvdrKPlfcRzlDn/OqKFThNimYmsS3flmkioKvkUGn2Qg9cJVoQiEvdxFGLE0MQER/9fZ9sUqdxg==",
-      "dev": true,
-      "dependencies": {
-        "test-value": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/reduce-without/node_modules/array-back": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-      "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
-      "dev": true,
-      "dependencies": {
-        "typical": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/reduce-without/node_modules/test-value": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-      "integrity": "sha512-+1epbAxtKeXttkGFMTX9H42oqzOTufR1ceCF+GYA5aOmvaPq9wd4PUS8329fn2RRLGNeUkgRLnVpycjx8DsO2w==",
-      "dev": true,
-      "dependencies": {
-        "array-back": "^1.0.3",
-        "typical": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/requizzle": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
       "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21"
       }
     },
     "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.6.tgz",
-      "integrity": "sha512-wc2cBWqJgkU3Iz5oztRkQbfVkbxoz5EhnCGOrnJvnLnQ7O0WhQUYyv18qQI79O8L7DdHrrlJNeCHd4VGpnaXKQ==",
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.6"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.34.6",
-        "@rollup/rollup-android-arm64": "4.34.6",
-        "@rollup/rollup-darwin-arm64": "4.34.6",
-        "@rollup/rollup-darwin-x64": "4.34.6",
-        "@rollup/rollup-freebsd-arm64": "4.34.6",
-        "@rollup/rollup-freebsd-x64": "4.34.6",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.34.6",
-        "@rollup/rollup-linux-arm-musleabihf": "4.34.6",
-        "@rollup/rollup-linux-arm64-gnu": "4.34.6",
-        "@rollup/rollup-linux-arm64-musl": "4.34.6",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.34.6",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.34.6",
-        "@rollup/rollup-linux-riscv64-gnu": "4.34.6",
-        "@rollup/rollup-linux-s390x-gnu": "4.34.6",
-        "@rollup/rollup-linux-x64-gnu": "4.34.6",
-        "@rollup/rollup-linux-x64-musl": "4.34.6",
-        "@rollup/rollup-win32-arm64-msvc": "4.34.6",
-        "@rollup/rollup-win32-ia32-msvc": "4.34.6",
-        "@rollup/rollup-win32-x64-msvc": "4.34.6",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/run-parallel": {
@@ -2068,14 +1917,15 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/sort-array": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-5.0.0.tgz",
-      "integrity": "sha512-Sg9MzajSGprcSrMIxsXyNT0e0JB47RJRfJspC+7co4Z5BdNsNl8FmWI+lXEpyKq+vkMG6pHgAhqyCO+bkDTfFQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-5.1.1.tgz",
+      "integrity": "sha512-EltS7AIsNlAFIM9cayrgKrM6XP94ATWwXP4LCL4IQbvbYhELSt2hZTrixg+AaQwnWFs/JGJgqU3rxMcNNWxGAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2094,21 +1944,12 @@
         }
       }
     },
-    "node_modules/sort-array/node_modules/typical": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
-      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2123,44 +1964,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/stream-connect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-      "integrity": "sha512-68Kl+79cE0RGKemKkhxTSg8+6AGrqBt+cbZAXevg2iJ6Y3zX4JhA/sZeGzLpxW9cXhmqAcE7KnJCisUmIUfnFQ==",
-      "dev": true,
-      "dependencies": {
-        "array-back": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stream-connect/node_modules/array-back": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-      "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
-      "dev": true,
-      "dependencies": {
-        "typical": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/stream-via": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
-      "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -2168,63 +1977,79 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/table-layout": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.5.tgz",
-      "integrity": "sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array-back": "^2.0.0",
-        "deep-extend": "~0.6.0",
-        "lodash.padend": "^4.6.1",
-        "typical": "^2.6.1",
-        "wordwrapjs": "^3.0.0"
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=12.17"
       }
     },
-    "node_modules/table-layout/node_modules/array-back": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "typical": "^2.6.1"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/temp-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
-      "integrity": "sha512-TvmyH7kC6ZVTYkqCODjJIbgvu0FKiwQpZ4D1aknE7xpcDf/qEOB8KZEK5ef2pfbVoiBhNWs3yx4y+ESMtNYmlg==",
-      "dev": true
-    },
-    "node_modules/test-value": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
-      "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
-      "dependencies": {
-        "array-back": "^2.0.0",
-        "typical": "^2.6.1"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
-    "node_modules/test-value/node_modules/array-back": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-      "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
-      "dependencies": {
-        "typical": "^2.6.1"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=4"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {
@@ -2240,23 +2065,37 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/typical": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
-      "dev": true
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
     },
     "node_modules/uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.2.tgz",
-      "integrity": "sha512-AaQNokTNgExWrkEYA24BTNMSjyqEXPSfhqoS0AxmHkCJ4U+Dyy5AvbGV/sqxuxficEfGGoX3zWw9R7QpLFfEsg==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -2266,37 +2105,30 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
-      "dev": true
-    },
-    "node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
+      "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.1.0.tgz",
-      "integrity": "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.24.2",
-        "postcss": "^8.5.1",
-        "rollup": "^4.30.1"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -2305,14 +2137,15 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "sass-embedded": "*",
-        "stylus": "*",
-        "sugarss": "*",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"
@@ -2321,13 +2154,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -2354,255 +2190,146 @@
       }
     },
     "node_modules/vite-plugin-static-copy": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.2.0.tgz",
-      "integrity": "sha512-ytMrKdR9iWEYHbUxs6x53m+MRl4SJsOSoMu1U1+Pfg0DjPeMlsRVx3RR5jvoonineDquIue83Oq69JvNsFSU5w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-4.1.1.tgz",
+      "integrity": "sha512-GrlA8YklrAfSyxJ4M3fdQLOo9oNkp56IM9FYgX/WtEgeIFkPwhu4wzpufBCIuNKCa6Fn77FkRdYxkHqV0FwjAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chokidar": "^3.5.3",
-        "fast-glob": "^3.2.11",
-        "fs-extra": "^11.1.0",
-        "picocolors": "^1.0.0"
+        "chokidar": "^3.6.0",
+        "p-map": "^7.0.4",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.17"
       },
       "engines": {
-        "node": "^18.0.0 || >=20.0.0"
+        "node": "^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/sapphi-red"
       },
       "peerDependencies": {
-        "vite": "^5.0.0 || ^6.0.0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/walk-back": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.1.0.tgz",
-      "integrity": "sha512-Uhxps5yZcVNbLEAnb+xaEEMdgTXl9qAQDzKYejG2AZ7qPwRQ81lozY9ECDbjLPNWm7YsO1IK5rsP1KoQzXAcGA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.1.2.tgz",
+      "integrity": "sha512-uCgzIY1U7fyXvJm+mesY0xjf2HXu7mtTnptONwVQ11ur1JhMrUyQJn2fDje1CGFQDnTFTo1Slr1vRuvUS9PYoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.17"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
       }
     },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wordwrapjs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
       "dev": true,
-      "dependencies": {
-        "reduce-flatten": "^1.0.1",
-        "typical": "^2.6.1"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=12.17"
       }
-    },
-    "node_modules/wordwrapjs/node_modules/reduce-flatten": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-      "integrity": "sha512-j5WfFJfc9CoXv/WbwVLHq74i/hdTUpy+iNC534LxczMRP67vJeK3V9JOdnL0N1cIRbn9mYhE2yVjvvKXDxvNXQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
     },
     "node_modules/xmlcreate": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
       "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     }
   },
   "dependencies": {
-    "@babel/parser": {
-      "version": "7.22.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.4.tgz",
-      "integrity": "sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==",
+    "@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true
     },
-    "@esbuild/aix-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
-      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
-      "dev": true,
-      "optional": true
+    "@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true
     },
-    "@esbuild/android-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
-      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+    "@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
-      "optional": true
+      "requires": {
+        "@babel/types": "^7.29.7"
+      }
     },
-    "@esbuild/android-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
-      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+    "@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
-      "optional": true
+      "requires": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      }
     },
-    "@esbuild/android-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
-      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+    "@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
     },
-    "@esbuild/darwin-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
-      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+    "@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
     },
-    "@esbuild/darwin-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
-      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+    "@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
-      "optional": true
-    },
-    "@esbuild/freebsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/freebsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
-      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-arm": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
-      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
-      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
-      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-loong64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
-      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-mips64el": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
-      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-ppc64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
-      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-riscv64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
-      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-s390x": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
-      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/linux-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
-      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/netbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/netbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/openbsd-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
-      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/openbsd-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
-      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/sunos-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
-      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/win32-arm64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
-      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/win32-ia32": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
-      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
-      "dev": true,
-      "optional": true
-    },
-    "@esbuild/win32-x64": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
-      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
     },
     "@harvard-lil/perma-js-sdk": {
       "version": "0.0.5",
@@ -2610,12 +2337,22 @@
       "integrity": "sha512-UJqks94Fu90k2D405HbI0wDErV0JLPKlZwNwzEkem4waZjGIJGgjzyeP+KTdt0y/Bhr+R6N3KvIA3ZbihGWI5w=="
     },
     "@jsdoc/salty": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.5.tgz",
-      "integrity": "sha512-TfRP53RqunNe2HBobVBJ0VLhK1HbfvBYeTC1ahnN64PWvyYyGebmMiPkuwvD9fpw2ZbkoPb8Q7mwy0aR8Z9rvw==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.12.tgz",
+      "integrity": "sha512-TuB0x50EoAvEX/UEWITd8Mkn3WhiTjSvbTMCLj0BhsQEl5iUzjXdA0bETEVpTk+5TGTLR6QktI9H4hLviVeaAQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash": "^4.18.1"
+      }
+    },
+    "@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@tybys/wasm-util": "^0.10.1"
       }
     },
     "@nodelib/fs.scandir": {
@@ -2644,164 +2381,156 @@
         "fastq": "^1.6.0"
       }
     },
+    "@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true
+    },
     "@playwright/test": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.23.4.tgz",
-      "integrity": "sha512-iIsoMJDS/lyuhw82FtcV/B3PXikgVD3hNe5hyvOpRM0uRr1OIpN3LgPeRbBjhzBWmyf6RgRg5fqK5sVcpA03yA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
-        "playwright-core": "1.23.4"
+        "playwright": "1.60.0"
       }
     },
-    "@rollup/rollup-android-arm-eabi": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.6.tgz",
-      "integrity": "sha512-+GcCXtOQoWuC7hhX1P00LqjjIiS/iOouHXhMdiDSnq/1DGTox4SpUvO52Xm+div6+106r+TcvOeo/cxvyEyTgg==",
+    "@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "dev": true,
       "optional": true
     },
-    "@rollup/rollup-android-arm64": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.6.tgz",
-      "integrity": "sha512-E8+2qCIjciYUnCa1AiVF1BkRgqIGW9KzJeesQqVfyRITGQN+dFuoivO0hnro1DjT74wXLRZ7QF8MIbz+luGaJA==",
+    "@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "dev": true,
       "optional": true
     },
-    "@rollup/rollup-darwin-arm64": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.6.tgz",
-      "integrity": "sha512-z9Ib+OzqN3DZEjX7PDQMHEhtF+t6Mi2z/ueChQPLS/qUMKY7Ybn5A2ggFoKRNRh1q1T03YTQfBTQCJZiepESAg==",
+    "@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "dev": true,
       "optional": true
     },
-    "@rollup/rollup-darwin-x64": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.6.tgz",
-      "integrity": "sha512-PShKVY4u0FDAR7jskyFIYVyHEPCPnIQY8s5OcXkdU8mz3Y7eXDJPdyM/ZWjkYdR2m0izD9HHWA8sGcXn+Qrsyg==",
+    "@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "dev": true,
       "optional": true
     },
-    "@rollup/rollup-freebsd-arm64": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.6.tgz",
-      "integrity": "sha512-YSwyOqlDAdKqs0iKuqvRHLN4SrD2TiswfoLfvYXseKbL47ht1grQpq46MSiQAx6rQEN8o8URtpXARCpqabqxGQ==",
+    "@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "dev": true,
       "optional": true
     },
-    "@rollup/rollup-freebsd-x64": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.6.tgz",
-      "integrity": "sha512-HEP4CgPAY1RxXwwL5sPFv6BBM3tVeLnshF03HMhJYCNc6kvSqBgTMmsEjb72RkZBAWIqiPUyF1JpEBv5XT9wKQ==",
+    "@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "dev": true,
       "optional": true
     },
-    "@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.6.tgz",
-      "integrity": "sha512-88fSzjC5xeH9S2Vg3rPgXJULkHcLYMkh8faix8DX4h4TIAL65ekwuQMA/g2CXq8W+NJC43V6fUpYZNjaX3+IIg==",
+    "@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "dev": true,
       "optional": true
     },
-    "@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.6.tgz",
-      "integrity": "sha512-wM4ztnutBqYFyvNeR7Av+reWI/enK9tDOTKNF+6Kk2Q96k9bwhDDOlnCUNRPvromlVXo04riSliMBs/Z7RteEg==",
+    "@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "dev": true,
       "optional": true
     },
-    "@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.6.tgz",
-      "integrity": "sha512-9RyprECbRa9zEjXLtvvshhw4CMrRa3K+0wcp3KME0zmBe1ILmvcVHnypZ/aIDXpRyfhSYSuN4EPdCCj5Du8FIA==",
+    "@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "dev": true,
       "optional": true
     },
-    "@rollup/rollup-linux-arm64-musl": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.6.tgz",
-      "integrity": "sha512-qTmklhCTyaJSB05S+iSovfo++EwnIEZxHkzv5dep4qoszUMX5Ca4WM4zAVUMbfdviLgCSQOu5oU8YoGk1s6M9Q==",
+    "@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "dev": true,
       "optional": true
     },
-    "@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.6.tgz",
-      "integrity": "sha512-4Qmkaps9yqmpjY5pvpkfOerYgKNUGzQpFxV6rnS7c/JfYbDSU0y6WpbbredB5cCpLFGJEqYX40WUmxMkwhWCjw==",
+    "@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "dev": true,
       "optional": true
     },
-    "@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.6.tgz",
-      "integrity": "sha512-Zsrtux3PuaxuBTX/zHdLaFmcofWGzaWW1scwLU3ZbW/X+hSsFbz9wDIp6XvnT7pzYRl9MezWqEqKy7ssmDEnuQ==",
+    "@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "dev": true,
       "optional": true
     },
-    "@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.6.tgz",
-      "integrity": "sha512-aK+Zp+CRM55iPrlyKiU3/zyhgzWBxLVrw2mwiQSYJRobCURb781+XstzvA8Gkjg/hbdQFuDw44aUOxVQFycrAg==",
+    "@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      }
+    },
+    "@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "dev": true,
       "optional": true
     },
-    "@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.6.tgz",
-      "integrity": "sha512-WoKLVrY9ogmaYPXwTH326+ErlCIgMmsoRSx6bO+l68YgJnlOXhygDYSZe/qbUJCSiCiZAQ+tKm88NcWuUXqOzw==",
+    "@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "dev": true,
       "optional": true
     },
-    "@rollup/rollup-linux-x64-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.6.tgz",
-      "integrity": "sha512-Sht4aFvmA4ToHd2vFzwMFaQCiYm2lDFho5rPcvPBT5pCdC+GwHG6CMch4GQfmWTQ1SwRKS0dhDYb54khSrjDWw==",
-      "dev": true,
-      "optional": true
+    "@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true
     },
-    "@rollup/rollup-linux-x64-musl": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.6.tgz",
-      "integrity": "sha512-zmmpOQh8vXc2QITsnCiODCDGXFC8LMi64+/oPpPx5qz3pqv0s6x46ps4xoycfUiVZps5PFn1gksZzo4RGTKT+A==",
+    "@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.6.tgz",
-      "integrity": "sha512-3/q1qUsO/tLqGBaD4uXsB6coVGB3usxw3qyeVb59aArCgedSF66MPdgRStUd7vbZOsko/CgVaY5fo2vkvPLWiA==",
-      "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.6.tgz",
-      "integrity": "sha512-oLHxuyywc6efdKVTxvc0135zPrRdtYVjtVD5GUm55I3ODxhU/PwkQFD97z16Xzxa1Fz0AEe4W/2hzRtd+IfpOA==",
-      "dev": true,
-      "optional": true
-    },
-    "@rollup/rollup-win32-x64-msvc": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.6.tgz",
-      "integrity": "sha512-0PVwmgzZ8+TZ9oGBmdZoQVXflbvuwzN/HRclujpl4N/q3i+y0lqLw8n1bXA8ru3sApDjlmONaNAuYr38y1Kr9w==",
-      "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
     },
     "@types/chrome": {
-      "version": "0.0.190",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.190.tgz",
-      "integrity": "sha512-lCwwIBfaD+PhG62qFB46mIBpD+xBIa+PedNB24KR9YnmJ0Zn9h0OwP1NQBhI8Cbu1rKwTQHTxhs7GhWGyUvinw==",
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.43.tgz",
+      "integrity": "sha512-ukH/HhmR6ht+UTX3PLUWJxgJ/RQcK2Foj4lBzsF24SIWsXgqhGuXqjd8FFuwioPP7d/JUKLM4g8GZxw3F4HTcA==",
       "dev": true,
       "requires": {
         "@types/filesystem": "*",
         "@types/har-format": "*"
       }
-    },
-    "@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true
     },
     "@types/filesystem": {
       "version": "0.0.32",
@@ -2825,54 +2554,40 @@
       "dev": true
     },
     "@types/linkify-it": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
       "dev": true
     },
     "@types/markdown-it": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
-      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "requires": {
-        "@types/linkify-it": "*",
-        "@types/mdurl": "*"
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
       }
     },
     "@types/mdurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "dev": true
     },
-    "@types/node": {
-      "version": "18.0.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
-      "integrity": "sha512-/xUq6H2aQm261exT6iZTMifUySEt4GR5KX8eYyY+C4MSNPqSh9oNIP7tz2GLKTlFaiBbgZNxffoR3CVRG+cljw==",
-      "dev": true
-    },
-    "ansi-escape-sequences": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.1.0.tgz",
-      "integrity": "sha512-dzW9kHxH011uBsidTXd14JXgzye/YLb2LzeKZ4bsgl/Knwx8AtbSFkkGxagdNOoh0DlqHCmfiEjWKBaqjOanVw==",
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "requires": {
-        "array-back": "^3.0.1"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-          "dev": true
-        }
+        "color-convert": "^2.0.1"
       }
     },
     "anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
@@ -2886,21 +2601,15 @@
       "dev": true
     },
     "array-back": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
-      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
-      "dev": true
-    },
-    "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
       "dev": true
     },
     "binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true
     },
     "bluebird": {
@@ -2908,16 +2617,6 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
     },
     "braces": {
       "version": "3.0.3",
@@ -2929,22 +2628,12 @@
       }
     },
     "cache-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-2.0.0.tgz",
-      "integrity": "sha512-4gkeHlFpSKgm3vm2gJN5sPqfmijYRFYCQ6tv5cLw0xVmT6r1z1vd4FNnpuOREco3cBs1G709sZ72LdgddKvL5w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/cache-point/-/cache-point-3.0.1.tgz",
+      "integrity": "sha512-itTIMLEKbh6Dw5DruXbxAgcyLnh/oPGVLBfTPqBOftASxHe8bAeXy7JkO4F0LvHqht7XqP5O/09h5UcHS2w0FA==",
       "dev": true,
       "requires": {
-        "array-back": "^4.0.1",
-        "fs-then-native": "^2.0.0",
-        "mkdirp2": "^1.0.4"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-          "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
-          "dev": true
-        }
+        "array-back": "^6.2.2"
       }
     },
     "catharsis": {
@@ -2956,10 +2645,29 @@
         "lodash": "^4.17.15"
       }
     },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.2"
+      }
+    },
     "chokidar": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
@@ -2972,99 +2680,49 @@
         "readdirp": "~3.6.0"
       }
     },
-    "collect-all": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.4.tgz",
-      "integrity": "sha512-RKZhRwJtJEP5FWul+gkSMEnaK6H3AGPTTWOiRimCcs+rc/OmQE3Yhy1Q7A7KsdkG3ZXVdZq68Y6ONSdvkeEcKA==",
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "requires": {
-        "stream-connect": "^1.0.2",
-        "stream-via": "^1.0.4"
+        "color-name": "~1.1.4"
       }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "command-line-args": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
-      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
+      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
       "dev": true,
       "requires": {
-        "array-back": "^3.1.0",
-        "find-replace": "^3.0.0",
+        "array-back": "^6.2.3",
+        "find-replace": "^5.0.2",
         "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-          "dev": true
-        },
-        "typical": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-          "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-          "dev": true
-        }
-      }
-    },
-    "command-line-tool": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/command-line-tool/-/command-line-tool-0.8.0.tgz",
-      "integrity": "sha512-Xw18HVx/QzQV3Sc5k1vy3kgtOeGmsKIqwtFFoyjI4bbcpSgnw2CWVULvtakyw4s6fhyAdI6soQQhXc2OzJy62g==",
-      "dev": true,
-      "requires": {
-        "ansi-escape-sequences": "^4.0.0",
-        "array-back": "^2.0.0",
-        "command-line-args": "^5.0.0",
-        "command-line-usage": "^4.1.0",
-        "typical": "^2.6.1"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-          "dev": true,
-          "requires": {
-            "typical": "^2.6.1"
-          }
-        }
+        "typical": "^7.3.0"
       }
     },
     "command-line-usage": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-4.1.0.tgz",
-      "integrity": "sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
       "dev": true,
       "requires": {
-        "ansi-escape-sequences": "^4.0.0",
-        "array-back": "^2.0.0",
-        "table-layout": "^0.4.2",
-        "typical": "^2.6.1"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-          "dev": true,
-          "requires": {
-            "typical": "^2.6.1"
-          }
-        }
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
       }
     },
     "common-sequence": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-2.0.2.tgz",
-      "integrity": "sha512-jAg09gkdkrDO9EWTdXfv80WWH3yeZl5oT69fGfedBNS9pXUKYInVJ1bJ+/ht2+Moeei48TmSbQDYMc8EOx9G0g==",
-      "dev": true
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/common-sequence/-/common-sequence-3.0.0.tgz",
+      "integrity": "sha512-g/CgSYk93y+a1IKm50tKl7kaT/OjjTYVQlEbUlt/49ZLV1mcKpUU7iyDiqTAeLdb4QDtQfq3ako8y8v//fzrWQ==",
       "dev": true
     },
     "config-master": {
@@ -3084,76 +2742,44 @@
         }
       }
     },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+    "current-module-paths": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/current-module-paths/-/current-module-paths-1.1.3.tgz",
+      "integrity": "sha512-7AH+ZTRKikdK4s1RmY0l6067UD/NZc7p3zZVZxvmnH80G31kr0y0W0E6ibYM4IS01MEm8DiC5FnTcgcgkbFHoA==",
+      "dev": true
+    },
+    "detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true
     },
     "dmd": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/dmd/-/dmd-6.1.0.tgz",
-      "integrity": "sha512-0zQIJ873gay1scCTFZvHPWM9mVJBnaylB2NQDI8O9u8O32m00Jb6uxDKexZm8hjTRM7RiWe0FJ32pExHoXdwoQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/dmd/-/dmd-7.1.1.tgz",
+      "integrity": "sha512-Ap2HP6iuOek7eShReDLr9jluNJm9RMZESlt29H/Xs1qrVMkcS9X6m5h1mBC56WMxNiSo0wvjGICmZlYUSFjwZQ==",
       "dev": true,
       "requires": {
         "array-back": "^6.2.2",
-        "cache-point": "^2.0.0",
-        "common-sequence": "^2.0.2",
-        "file-set": "^4.0.2",
-        "handlebars": "^4.7.7",
-        "marked": "^4.0.12",
-        "object-get": "^2.1.1",
-        "reduce-flatten": "^3.0.1",
-        "reduce-unique": "^2.0.1",
-        "reduce-without": "^1.0.1",
-        "test-value": "^3.0.0",
-        "walk-back": "^5.1.0"
+        "cache-point": "^3.0.0",
+        "common-sequence": "^3.0.0",
+        "file-set": "^5.2.2",
+        "handlebars": "^4.7.8",
+        "marked": "^4.3.0",
+        "walk-back": "^5.1.1"
       }
     },
     "dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "dev": true
     },
     "entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true
-    },
-    "esbuild": {
-      "version": "0.24.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
-      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
-      "dev": true,
-      "requires": {
-        "@esbuild/aix-ppc64": "0.24.2",
-        "@esbuild/android-arm": "0.24.2",
-        "@esbuild/android-arm64": "0.24.2",
-        "@esbuild/android-x64": "0.24.2",
-        "@esbuild/darwin-arm64": "0.24.2",
-        "@esbuild/darwin-x64": "0.24.2",
-        "@esbuild/freebsd-arm64": "0.24.2",
-        "@esbuild/freebsd-x64": "0.24.2",
-        "@esbuild/linux-arm": "0.24.2",
-        "@esbuild/linux-arm64": "0.24.2",
-        "@esbuild/linux-ia32": "0.24.2",
-        "@esbuild/linux-loong64": "0.24.2",
-        "@esbuild/linux-mips64el": "0.24.2",
-        "@esbuild/linux-ppc64": "0.24.2",
-        "@esbuild/linux-riscv64": "0.24.2",
-        "@esbuild/linux-s390x": "0.24.2",
-        "@esbuild/linux-x64": "0.24.2",
-        "@esbuild/netbsd-arm64": "0.24.2",
-        "@esbuild/netbsd-x64": "0.24.2",
-        "@esbuild/openbsd-arm64": "0.24.2",
-        "@esbuild/openbsd-x64": "0.24.2",
-        "@esbuild/sunos-x64": "0.24.2",
-        "@esbuild/win32-arm64": "0.24.2",
-        "@esbuild/win32-ia32": "0.24.2",
-        "@esbuild/win32-x64": "0.24.2"
-      }
     },
     "escape-string-regexp": {
       "version": "2.0.0",
@@ -3162,43 +2788,35 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       }
     },
     "fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
       }
     },
     "file-set": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/file-set/-/file-set-4.0.2.tgz",
-      "integrity": "sha512-fuxEgzk4L8waGXaAkd8cMr73Pm0FxOVkn8hztzUW7BAHhOGH90viQNXbiOsnecCWmfInqU6YmAMwxRMdKETceQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/file-set/-/file-set-5.3.0.tgz",
+      "integrity": "sha512-FKCxdjLX0J6zqTWdT0RXIxNF/n7MyXXnsSUp0syLEOCKdexvPZ02lNNv2a+gpK9E3hzUYF3+eFZe32ci7goNUg==",
       "dev": true,
       "requires": {
-        "array-back": "^5.0.0",
-        "glob": "^7.1.6"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-5.0.0.tgz",
-          "integrity": "sha512-kgVWwJReZWmVuWOQKEOohXKJX+nD02JAZ54D1RRWlv8L0NebauKAaFxACKzB74RTclt1+WNz5KHaLRDAPZbDEw==",
-          "dev": true
-        }
+        "array-back": "^6.2.2",
+        "fast-glob": "^3.3.2"
       }
     },
     "fill-range": {
@@ -3211,44 +2829,11 @@
       }
     },
     "find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
       "dev": true,
-      "requires": {
-        "array-back": "^3.0.1"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-          "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-          "dev": true
-        }
-      }
-    },
-    "fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      }
-    },
-    "fs-then-native": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fs-then-native/-/fs-then-native-2.0.0.tgz",
-      "integrity": "sha512-X712jAOaWXkemQCAmWeg5rOT2i+KOpWz1Z/txk/cW0qlOu2oQ9H61vc5w3X/iyuUEfq/OyaFJ78/cZAQD1/bgA==",
-      "dev": true
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "requires": {}
     },
     "fsevents": {
       "version": "2.3.3",
@@ -3256,20 +2841,6 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "optional": true
-    },
-    "glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
     },
     "glob-parent": {
       "version": "5.1.2",
@@ -3281,38 +2852,28 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       }
     },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
     "is-binary-path": {
@@ -3355,21 +2916,21 @@
       }
     },
     "jsdoc": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.2.tgz",
-      "integrity": "sha512-e8cIg2z62InH7azBBi3EsSEqrKx+nUtAS5bBcYTSpZFA+vhNPyhv8PTFZ0WsjOPDj04/dOLlm08EDcQJDqaGQg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.5.tgz",
+      "integrity": "sha512-P4C6MWP9yIlMiK8nwoZvxN84vb6MsnXcHuy7XzVOvQoCizWX5JFCBsWIIWKXBltpoRZXddUOVQmCTOZt9yDj9g==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.20.15",
         "@jsdoc/salty": "^0.2.1",
-        "@types/markdown-it": "^12.2.3",
+        "@types/markdown-it": "^14.1.1",
         "bluebird": "^3.7.2",
         "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.2",
         "klaw": "^3.0.0",
-        "markdown-it": "^12.3.2",
-        "markdown-it-anchor": "^8.4.1",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^8.6.7",
         "marked": "^4.0.10",
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
@@ -3378,66 +2939,45 @@
       }
     },
     "jsdoc-api": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-7.2.0.tgz",
-      "integrity": "sha512-93YDnlm/OYTlLOFeNs4qAv0RBCJ0kGj67xQaWy8wrbk97Rw1EySitoOTHsTHXPEs3uyx2IStPKGrbE7LTnZXbA==",
+      "version": "9.3.6",
+      "resolved": "https://registry.npmjs.org/jsdoc-api/-/jsdoc-api-9.3.6.tgz",
+      "integrity": "sha512-8JW0532+rXVw8LoZ1LIAeKofsV8QQZhnY3chxMHV9hQdsuDTshsajwk0b4EMxCqen2vZ2op/r/qeEsqZxsEQyg==",
       "dev": true,
       "requires": {
-        "array-back": "^6.2.2",
-        "cache-point": "^2.0.0",
-        "collect-all": "^1.0.4",
-        "file-set": "^4.0.2",
-        "fs-then-native": "^2.0.0",
-        "jsdoc": "^4.0.0",
+        "array-back": "^6.2.3",
+        "cache-point": "^3.0.1",
+        "current-module-paths": "^1.1.3",
+        "file-set": "^5.3.0",
+        "jsdoc": "^4.0.5",
         "object-to-spawn-args": "^2.0.1",
-        "temp-path": "^1.0.0",
-        "walk-back": "^5.1.0"
+        "walk-back": "^5.1.2"
       }
     },
     "jsdoc-parse": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.2.4.tgz",
-      "integrity": "sha512-MQA+lCe3ioZd0uGbyB3nDCDZcKgKC7m/Ivt0LgKZdUoOlMJxUWJQ3WI6GeyHp9ouznKaCjlp7CU9sw5k46yZTw==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/jsdoc-parse/-/jsdoc-parse-6.2.5.tgz",
+      "integrity": "sha512-8JaSNjPLr2IuEY4Das1KM6Z4oLHZYUnjRrr27hKSa78Cj0i5Lur3DzNnCkz+DfrKBDoljGMoWOiBVQbtUZJBPw==",
       "dev": true,
       "requires": {
         "array-back": "^6.2.2",
         "find-replace": "^5.0.1",
-        "lodash.omit": "^4.5.0",
         "sort-array": "^5.0.0"
-      },
-      "dependencies": {
-        "find-replace": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
-          "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
-          "dev": true,
-          "requires": {}
-        }
       }
     },
     "jsdoc-to-markdown": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-7.1.1.tgz",
-      "integrity": "sha512-CI86d63xAVNO+ENumWwmJ034lYe5iGU5GwjtTA11EuphP9tpnoi4hrKgR/J8uME0D+o4KUpVfwX1fjZhc8dEtg==",
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/jsdoc-to-markdown/-/jsdoc-to-markdown-9.1.3.tgz",
+      "integrity": "sha512-i9wi+6WHX0WKziv0ar88T8h7OmxA0LWdQaV23nY6uQyKvdUPzVt0o6YAaOceFuKRF5Rvlju5w/KnZBfdpDAlnw==",
       "dev": true,
       "requires": {
         "array-back": "^6.2.2",
-        "command-line-tool": "^0.8.0",
+        "command-line-args": "^6.0.1",
+        "command-line-usage": "^7.0.3",
         "config-master": "^3.1.0",
-        "dmd": "^6.1.0",
-        "jsdoc-api": "^7.1.1",
-        "jsdoc-parse": "^6.1.0",
-        "walk-back": "^5.1.0"
-      }
-    },
-    "jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.6",
-        "universalify": "^2.0.0"
+        "dmd": "^7.1.1",
+        "jsdoc-api": "^9.3.5",
+        "jsdoc-parse": "^6.2.5",
+        "walk-back": "^5.1.1"
       }
     },
     "klaw": {
@@ -3449,19 +2989,116 @@
         "graceful-fs": "^4.1.9"
       }
     },
-    "linkify-it": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
-      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+    "lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "requires": {
-        "uc.micro": "^1.0.1"
+        "detect-libc": "^2.0.3",
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "dev": true,
+      "optional": true
+    },
+    "lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "dev": true,
+      "optional": true
+    },
+    "linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^2.0.0"
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true
     },
     "lodash.camelcase": {
@@ -3470,29 +3107,18 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true
     },
-    "lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==",
-      "dev": true
-    },
-    "lodash.padend": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha512-sOQs2aqGpbl27tmCS1QNZA09Uqp01ZzWfDUoD+xzTii0E7dSQfRKcRetFwa+uXaxaqL+TKm7CgD2JdKP7aZBSw==",
-      "dev": true
-    },
     "markdown-it": {
-      "version": "12.3.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
-      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
-        "mdurl": "^1.0.1",
-        "uc.micro": "^1.0.5"
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
       }
     },
     "markdown-it-anchor": {
@@ -3503,15 +3129,15 @@
       "requires": {}
     },
     "marked": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.17.tgz",
-      "integrity": "sha512-Wfk0ATOK5iPxM4ptrORkFemqroz0ZDxp5MWfYA7H/F+wO17NRWV5Ypxi6p3g2Xmw2bKeiYOl6oVnLHKxBA0VhA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
       "dev": true
     },
     "mdurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true
     },
     "merge2": {
@@ -3530,19 +3156,10 @@
         "picomatch": "^2.3.1"
       }
     },
-    "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "mkdirp": {
@@ -3551,16 +3168,10 @@
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
     },
-    "mkdirp2": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/mkdirp2/-/mkdirp2-1.0.5.tgz",
-      "integrity": "sha512-xOE9xbICroUDmG1ye2h4bZ8WBie9EGmACaco8K8cx6RlkJJrxGIqjGqztAI+NMhexXBcdGbSEzI6N3EJPevxZw==",
-      "dev": true
-    },
     "nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true
     },
     "neo-async": {
@@ -3575,31 +3186,16 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
-    "object-get": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.1.tgz",
-      "integrity": "sha512-7n4IpLMzGGcLEMiQKsNR7vCe+N5E9LORFrtNUVy4sO3dj9a3HedZCxEL2T7QuLhcHN1NBuBsMOKaOsAYI9IIvg==",
-      "dev": true
-    },
     "object-to-spawn-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object-to-spawn-args/-/object-to-spawn-args-2.0.1.tgz",
       "integrity": "sha512-6FuKFQ39cOID+BMZ3QaphcC8Y4cw6LXBLyIgPU+OhIYwviJamPAn+4mITapnSBQrejB+NNp+FMskhD8Cq+Ys3w==",
       "dev": true
     },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+    "p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
       "dev": true
     },
     "picocolors": {
@@ -3609,32 +3205,57 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true
     },
+    "playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.60.0"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "playwright-core": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.23.4.tgz",
-      "integrity": "sha512-h5V2yw7d8xIwotjyNrkLF13nV9RiiZLHdXeHo+nVJIYGVlZ8U2qV0pMxNJKNTvfQVT0N8/A4CW6/4EW2cOcTiA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true
     },
     "postcss": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.2.tgz",
-      "integrity": "sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "requires": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       }
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true
+    },
+    "punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "dev": true
     },
     "queue-microtask": {
@@ -3652,48 +3273,6 @@
         "picomatch": "^2.2.1"
       }
     },
-    "reduce-flatten": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-3.0.1.tgz",
-      "integrity": "sha512-bYo+97BmUUOzg09XwfkwALt4PQH1M5L0wzKerBt6WLm3Fhdd43mMS89HiT1B9pJIqko/6lWx3OnV4J9f2Kqp5Q==",
-      "dev": true
-    },
-    "reduce-unique": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-unique/-/reduce-unique-2.0.1.tgz",
-      "integrity": "sha512-x4jH/8L1eyZGR785WY+ePtyMNhycl1N2XOLxhCbzZFaqF4AXjLzqSxa2UHgJ2ZVR/HHyPOvl1L7xRnW8ye5MdA==",
-      "dev": true
-    },
-    "reduce-without": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/reduce-without/-/reduce-without-1.0.1.tgz",
-      "integrity": "sha512-zQv5y/cf85sxvdrKPlfcRzlDn/OqKFThNimYmsS3flmkioKvkUGn2Qg9cJVoQiEvdxFGLE0MQER/9fZ9sUqdxg==",
-      "dev": true,
-      "requires": {
-        "test-value": "^2.0.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
-          "dev": true,
-          "requires": {
-            "typical": "^2.6.0"
-          }
-        },
-        "test-value": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
-          "integrity": "sha512-+1epbAxtKeXttkGFMTX9H42oqzOTufR1ceCF+GYA5aOmvaPq9wd4PUS8329fn2RRLGNeUkgRLnVpycjx8DsO2w==",
-          "dev": true,
-          "requires": {
-            "array-back": "^1.0.3",
-            "typical": "^2.6.0"
-          }
-        }
-      }
-    },
     "requizzle": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
@@ -3704,38 +3283,34 @@
       }
     },
     "reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true
     },
-    "rollup": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.6.tgz",
-      "integrity": "sha512-wc2cBWqJgkU3Iz5oztRkQbfVkbxoz5EhnCGOrnJvnLnQ7O0WhQUYyv18qQI79O8L7DdHrrlJNeCHd4VGpnaXKQ==",
+    "rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "requires": {
-        "@rollup/rollup-android-arm-eabi": "4.34.6",
-        "@rollup/rollup-android-arm64": "4.34.6",
-        "@rollup/rollup-darwin-arm64": "4.34.6",
-        "@rollup/rollup-darwin-x64": "4.34.6",
-        "@rollup/rollup-freebsd-arm64": "4.34.6",
-        "@rollup/rollup-freebsd-x64": "4.34.6",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.34.6",
-        "@rollup/rollup-linux-arm-musleabihf": "4.34.6",
-        "@rollup/rollup-linux-arm64-gnu": "4.34.6",
-        "@rollup/rollup-linux-arm64-musl": "4.34.6",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.34.6",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.34.6",
-        "@rollup/rollup-linux-riscv64-gnu": "4.34.6",
-        "@rollup/rollup-linux-s390x-gnu": "4.34.6",
-        "@rollup/rollup-linux-x64-gnu": "4.34.6",
-        "@rollup/rollup-linux-x64-musl": "4.34.6",
-        "@rollup/rollup-win32-arm64-msvc": "4.34.6",
-        "@rollup/rollup-win32-ia32-msvc": "4.34.6",
-        "@rollup/rollup-win32-x64-msvc": "4.34.6",
-        "@types/estree": "1.0.6",
-        "fsevents": "~2.3.2"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3",
+        "@rolldown/pluginutils": "^1.0.0"
       }
     },
     "run-parallel": {
@@ -3748,21 +3323,13 @@
       }
     },
     "sort-array": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-5.0.0.tgz",
-      "integrity": "sha512-Sg9MzajSGprcSrMIxsXyNT0e0JB47RJRfJspC+7co4Z5BdNsNl8FmWI+lXEpyKq+vkMG6pHgAhqyCO+bkDTfFQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/sort-array/-/sort-array-5.1.1.tgz",
+      "integrity": "sha512-EltS7AIsNlAFIM9cayrgKrM6XP94ATWwXP4LCL4IQbvbYhELSt2hZTrixg+AaQwnWFs/JGJgqU3rxMcNNWxGAA==",
       "dev": true,
       "requires": {
         "array-back": "^6.2.2",
         "typical": "^7.1.1"
-      },
-      "dependencies": {
-        "typical": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
-          "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
-          "dev": true
-        }
       }
     },
     "source-map": {
@@ -3777,86 +3344,53 @@
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true
     },
-    "stream-connect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
-      "integrity": "sha512-68Kl+79cE0RGKemKkhxTSg8+6AGrqBt+cbZAXevg2iJ6Y3zX4JhA/sZeGzLpxW9cXhmqAcE7KnJCisUmIUfnFQ==",
-      "dev": true,
-      "requires": {
-        "array-back": "^1.0.2"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
-          "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
-          "dev": true,
-          "requires": {
-            "typical": "^2.6.0"
-          }
-        }
-      }
-    },
-    "stream-via": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
-      "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
-      "dev": true
-    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
-    "table-layout": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.4.5.tgz",
-      "integrity": "sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==",
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "requires": {
-        "array-back": "^2.0.0",
-        "deep-extend": "~0.6.0",
-        "lodash.padend": "^4.6.1",
-        "typical": "^2.6.1",
-        "wordwrapjs": "^3.0.0"
-      },
-      "dependencies": {
-        "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
-          "dev": true,
-          "requires": {
-            "typical": "^2.6.1"
-          }
-        }
+        "has-flag": "^4.0.0"
       }
     },
-    "temp-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/temp-path/-/temp-path-1.0.0.tgz",
-      "integrity": "sha512-TvmyH7kC6ZVTYkqCODjJIbgvu0FKiwQpZ4D1aknE7xpcDf/qEOB8KZEK5ef2pfbVoiBhNWs3yx4y+ESMtNYmlg==",
-      "dev": true
-    },
-    "test-value": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
-      "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
+    "table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
       "dev": true,
       "requires": {
-        "array-back": "^2.0.0",
-        "typical": "^2.6.1"
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      }
+    },
+    "tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "requires": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "dependencies": {
-        "array-back": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-2.0.0.tgz",
-          "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
+        "fdir": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+          "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
           "dev": true,
-          "requires": {
-            "typical": "^2.6.1"
-          }
+          "requires": {}
+        },
+        "picomatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+          "dev": true
         }
       }
     },
@@ -3869,66 +3403,78 @@
         "is-number": "^7.0.0"
       }
     },
+    "tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "optional": true
+    },
     "typical": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-      "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
       "dev": true
     },
     "uc.micro": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.2.tgz",
-      "integrity": "sha512-AaQNokTNgExWrkEYA24BTNMSjyqEXPSfhqoS0AxmHkCJ4U+Dyy5AvbGV/sqxuxficEfGGoX3zWw9R7QpLFfEsg==",
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
       "dev": true,
       "optional": true
     },
     "underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
-      "dev": true
-    },
-    "universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true
     },
     "vite": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.1.0.tgz",
-      "integrity": "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "requires": {
-        "esbuild": "^0.24.2",
         "fsevents": "~2.3.3",
-        "postcss": "^8.5.1",
-        "rollup": "^4.30.1"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "dependencies": {
+        "picomatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+          "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+          "dev": true
+        }
       }
     },
     "vite-plugin-static-copy": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-2.2.0.tgz",
-      "integrity": "sha512-ytMrKdR9iWEYHbUxs6x53m+MRl4SJsOSoMu1U1+Pfg0DjPeMlsRVx3RR5jvoonineDquIue83Oq69JvNsFSU5w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-4.1.1.tgz",
+      "integrity": "sha512-GrlA8YklrAfSyxJ4M3fdQLOo9oNkp56IM9FYgX/WtEgeIFkPwhu4wzpufBCIuNKCa6Fn77FkRdYxkHqV0FwjAw==",
       "dev": true,
       "requires": {
-        "chokidar": "^3.5.3",
-        "fast-glob": "^3.2.11",
-        "fs-extra": "^11.1.0",
-        "picocolors": "^1.0.0"
+        "chokidar": "^3.6.0",
+        "p-map": "^7.0.4",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.17"
       }
     },
     "walk-back": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.1.0.tgz",
-      "integrity": "sha512-Uhxps5yZcVNbLEAnb+xaEEMdgTXl9qAQDzKYejG2AZ7qPwRQ81lozY9ECDbjLPNWm7YsO1IK5rsP1KoQzXAcGA==",
-      "dev": true
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/walk-back/-/walk-back-5.1.2.tgz",
+      "integrity": "sha512-uCgzIY1U7fyXvJm+mesY0xjf2HXu7mtTnptONwVQ11ur1JhMrUyQJn2fDje1CGFQDnTFTo1Slr1vRuvUS9PYoQ==",
+      "dev": true,
+      "requires": {}
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -3937,27 +3483,9 @@
       "dev": true
     },
     "wordwrapjs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-3.0.0.tgz",
-      "integrity": "sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==",
-      "dev": true,
-      "requires": {
-        "reduce-flatten": "^1.0.1",
-        "typical": "^2.6.1"
-      },
-      "dependencies": {
-        "reduce-flatten": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
-          "integrity": "sha512-j5WfFJfc9CoXv/WbwVLHq74i/hdTUpy+iNC534LxczMRP67vJeK3V9JOdnL0N1cIRbn9mYhE2yVjvvKXDxvNXQ==",
-          "dev": true
-        }
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
       "dev": true
     },
     "xmlcreate": {

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "test": "npx playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "^1.23.4",
-    "@types/chrome": "^0.0.190",
-    "dotenv": "^16.0.1",
-    "jsdoc-to-markdown": "^7.1.1",
-    "prettier": "^2.6.2",
-    "vite": "^6.1.0",
-    "vite-plugin-static-copy": "^2.2.0"
+    "@playwright/test": "^1.60.0",
+    "@types/chrome": "^0.1.43",
+    "dotenv": "^17.4.2",
+    "jsdoc-to-markdown": "^9.1.3",
+    "prettier": "^3.8.3",
+    "vite": "^8.0.16",
+    "vite-plugin-static-copy": "^4.1.1"
   },
   "dependencies": {
     "@harvard-lil/perma-js-sdk": "^0.0.5"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -139,6 +139,10 @@
     "message": "Create a public Perma Link for the current page."
   },
 
+  "not_capturable_panel_message": {
+    "message": "Perma can only capture public web pages, so this page can’t be archived."
+  },
+
   "archive_timeline_empty": {
     "message": "You have no Perma Links for this page."
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -89,8 +89,26 @@
   "create_archive_form_select_label": {
     "message": "Select the folder for this Perma Link."
   },
-  "create_archive_form_select_default": {
-    "message": "Unspecified folder"
+  "create_archive_form_subfolder_choose": {
+    "message": "[Choose subfolder]"
+  },
+  "create_archive_form_subfolder_parent": {
+    "message": "[$folder$]",
+    "placeholders": {
+      "folder": {
+        "content": "$1",
+        "example": "Personal Links"
+      }
+    }
+  },
+  "create_archive_form_folder_has_children": {
+    "message": "›"
+  },
+  "create_archive_form_breadcrumb_intro": {
+    "message": ">"
+  },
+  "create_archive_form_folders_loading": {
+    "message": "Loading folders …"
   },
   "create_archive_form_button_caption": {
     "message": "Archive this page"

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -56,6 +56,28 @@
   "error_toggling_archive_privacy_status": {
     "message": "⚠️ Couldn't edit Perma Link."
   },
+  "error_api_key_invalid": {
+    "message": "⚠️ Your API key is no longer valid."
+  },
+
+  "invalid_key_panel_intro": {
+    "message": "⚠️ Your API key is no longer valid. Retry, or update your key to continue."
+  },
+  "invalid_key_panel_intro_with_hint": {
+    "message": "⚠️ Your API key (ending …$hint$) is no longer valid. Retry, or update your key to continue.",
+    "placeholders": {
+      "hint": {
+        "content": "$1",
+        "example": "aB3z"
+      }
+    }
+  },
+  "invalid_key_panel_retry_button_label": {
+    "message": "Retry"
+  },
+  "invalid_key_panel_update_button_label": {
+    "message": "Update key"
+  },
 
   "app_header_title": {
     "message": "Create a new Perma Link"

--- a/src/background/archiveCreate.js
+++ b/src/background/archiveCreate.js
@@ -41,16 +41,21 @@ export async function archiveCreate(isPrivate = false) {
       throw new Error("`currentTab.url` is not set.");
     }
 
-    await api.createArchive(currentTab.url, {
+    const archive = await api.createArchive(currentTab.url, {
       isPrivate: Boolean(isPrivate),
       parentFolderId: folders.pick
     });
 
     await Status.update((status) => {
       status.message = "status_archive_created";
+
+      // Track the new capture so the popup can poll its capture-job status (instead of
+      // re-pulling the whole timeline on a fixed interval). See `archivePullCaptureStatus`.
+      status.captureGuid = archive?.guid;
+      status.captureStep = 0;
     });
 
-    await archivePullTimeline(); // Will update the timeline once the archive is created
+    await archivePullTimeline(); // Shows the new (pending) archive in the timeline right away.
   }
   catch(err) {
     await Status.update((status) => { status.message = "error_creating_archive"; });

--- a/src/background/archiveCreate.js
+++ b/src/background/archiveCreate.js
@@ -24,16 +24,16 @@ import { PERMA_API_BASE_URL } from "../constants/index.js";
  * @async
  */
 export async function archiveCreate(isPrivate = false) {
-  const status = await Status.fromStorage();
   const auth = await Auth.fromStorage();
   const currentTab = await CurrentTab.fromStorage();
   const folders = await Folders.fromStorage();
 
   try {
-    status.isLoading = true;
-    status.lastLoadingInit = new Date();
-    status.message = "status_in_progress";
-    await status.save();
+    await Status.update((status) => {
+      status.isLoading = true;
+      status.lastLoadingInit = new Date();
+      status.message = "status_in_progress";
+    });
 
     const api = new PermaAPI(String(auth.apiKey), PERMA_API_BASE_URL);
 
@@ -42,21 +42,22 @@ export async function archiveCreate(isPrivate = false) {
     }
 
     await api.createArchive(currentTab.url, {
-      isPrivate: Boolean(isPrivate), 
+      isPrivate: Boolean(isPrivate),
       parentFolderId: folders.pick
     });
 
-    status.message = "status_archive_created";
+    await Status.update((status) => {
+      status.message = "status_archive_created";
+    });
 
     await archivePullTimeline(); // Will update the timeline once the archive is created
   }
   catch(err) {
-    status.message = "error_creating_archive";
+    await Status.update((status) => { status.message = "error_creating_archive"; });
     //console.error(err);
     throw err;
   }
   finally {
-    status.isLoading = false;
-    await status.save();
+    await Status.update((status) => { status.isLoading = false; });
   }
 }

--- a/src/background/archiveDelete.js
+++ b/src/background/archiveDelete.js
@@ -24,29 +24,28 @@ import { PERMA_API_BASE_URL } from "../constants/index.js";
  * @async
  */
 export async function archiveDelete(guid) {
-  const status = await Status.fromStorage();
   const auth = await Auth.fromStorage();
 
   try {
-    status.isLoading = true;
-    status.lastLoadingInit = new Date();
-    await status.save();
+    await Status.update((status) => {
+      status.isLoading = true;
+      status.lastLoadingInit = new Date();
+    });
 
     const api = new PermaAPI(String(auth.apiKey), PERMA_API_BASE_URL);
 
     await api.deleteArchive(guid);
 
-    status.message = "status_archive_deleted";
-    
-    await archivePullTimeline(); // Will update the timeline once the archive is created
+    await Status.update((status) => { status.message = "status_archive_deleted"; });
+
+    await archivePullTimeline(); // Will update the timeline once the archive is deleted.
   }
   catch(err) {
-    status.message = "error_deleting_archive";
+    await Status.update((status) => { status.message = "error_deleting_archive"; });
     //console.error(err);
     throw err;
   }
   finally {
-    status.isLoading = false;
-    await status.save();
+    await Status.update((status) => { status.isLoading = false; });
   }
 }

--- a/src/background/archiveDelete.js
+++ b/src/background/archiveDelete.js
@@ -34,7 +34,10 @@ export async function archiveDelete(guid) {
 
     const api = new PermaAPI(String(auth.apiKey), PERMA_API_BASE_URL);
 
-    await api.deleteArchive(guid);
+    // `safeMode=false`: the extension only ever deletes archives the timeline already shows as
+    // finished, so skip the SDK's safe-mode pre-delete `pullArchive` + up-to-~60s polling for
+    // pending captures. The delete becomes a single request.
+    await api.deleteArchive(guid, false);
 
     await Status.update((status) => { status.message = "status_archive_deleted"; });
 

--- a/src/background/archivePullCaptureStatus.js
+++ b/src/background/archivePullCaptureStatus.js
@@ -1,0 +1,87 @@
+/**
+ * perma-extension
+ * @module background/archivePullCaptureStatus
+ * @author The Harvard Library Innovation Lab
+ * @license MIT
+ * @description Handler for the `ARCHIVE_PULL_CAPTURE_STATUS` runtime message.
+ */
+// @ts-check
+
+import { PermaAPI, PermaAPIError } from "@harvard-lil/perma-js-sdk";
+import { Auth, Status } from "../storage/index.js";
+import { archivePullTimeline } from "./archivePullTimeline.js";
+import { PERMA_API_BASE_URL } from "../constants/index.js";
+
+/**
+ * Capture-job statuses that mean the capture is no longer running.
+ * See `PermaCaptureJob.status` in `perma-js-sdk`.
+ * @constant
+ */
+const TERMINAL_STATUSES = ["completed", "failed", "invalid", "deleted"];
+
+/**
+ * Handler for the `ARCHIVE_PULL_CAPTURE_STATUS` runtime message:
+ * Pulls the capture-job status for the archive currently being captured (`status.captureGuid`)
+ * and reflects its progress in storage.
+ *
+ * This is the lightweight, capture-scoped poll that replaces re-pulling the whole archive
+ * timeline on a fixed interval: it only does anything while a capture is in flight, hits the
+ * small `/v1/capture_jobs/{guid}` endpoint, and stops (clears `captureGuid`) once the job
+ * reaches a terminal state — at which point the timeline is refreshed once to show the result.
+ *
+ * @returns {Promise<void>}
+ * @async
+ */
+export async function archivePullCaptureStatus() {
+  const auth = await Auth.fromStorage();
+  const status = await Status.fromStorage();
+
+  // Nothing is being captured: no-op (and therefore no network traffic).
+  if (!status.captureGuid) {
+    return;
+  }
+
+  // The capture we're polling. If a newer capture takes over `captureGuid` while we await the
+  // network, the guards below skip our writes so we don't clobber it with this one's progress.
+  const polledGuid = status.captureGuid;
+
+  const api = new PermaAPI(String(auth.apiKey), PERMA_API_BASE_URL);
+
+  let captureJob;
+  try {
+    captureJob = await api.pullArchiveCaptureJob(polledGuid);
+  }
+  catch (err) {
+    // If the archive/job no longer exists, stop tracking it so we don't poll forever.
+    if (err instanceof PermaAPIError && err.httpStatusCode === 404) {
+      await Status.update((status) => {
+        if (status.captureGuid !== polledGuid) return false; // A newer capture took over; leave it.
+        status.captureGuid = "";
+        status.captureStep = 0;
+      });
+      return;
+    }
+    throw err;
+  }
+
+  // Still running: record progress for the timeline's progress bar and keep polling.
+  if (!TERMINAL_STATUSES.includes(captureJob.status)) {
+    await Status.update((status) => {
+      if (status.captureGuid !== polledGuid) return false;
+      status.captureStep = captureJob.step_count;
+    });
+    return;
+  }
+
+  // Terminal: stop polling and refresh the timeline once to show the final state.
+  await Status.update((status) => {
+    if (status.captureGuid !== polledGuid) return false;
+    status.captureGuid = "";
+    status.captureStep = 0;
+    if (captureJob.status === "failed" || captureJob.status === "invalid") {
+      status.message = "error_creating_archive";
+    }
+  });
+
+  await archivePullTimeline();
+}

--- a/src/background/archivePullTimeline.js
+++ b/src/background/archivePullTimeline.js
@@ -33,16 +33,7 @@ export async function archivePullTimeline() {
 
     const archivesFromAPI = await api.pullArchives(100, 0, currentTab.url);
 
-    // Debug: Filter-out entries that don't exactly match the current url.
-    const filteredArchives = [];
-
-    for (let archive of archivesFromAPI.objects) {
-      if (new URL(archive.url).href === currentTab.url) {
-        filteredArchives.push(archive);
-      }
-    }
-
-    archives.byUrl[currentTab.url] = filteredArchives;
+    archives.byUrl[currentTab.url] = archivesFromAPI.objects;
   }
   catch(err) {
     //console.error(err);

--- a/src/background/archiveTogglePrivacyStatus.js
+++ b/src/background/archiveTogglePrivacyStatus.js
@@ -25,30 +25,32 @@ import { PERMA_API_BASE_URL } from "../constants/index.js";
  * @async
  */
 export async function archiveTogglePrivacyStatus(guid, isPrivate = false) {
-  const status = await Status.fromStorage();
   const auth = await Auth.fromStorage();
 
   try {
-    status.isLoading = true;
-    status.message = "status_in_progress";
-    status.lastLoadingInit = new Date();
-    await status.save();
+    await Status.update((status) => {
+      status.isLoading = true;
+      status.message = "status_in_progress";
+      status.lastLoadingInit = new Date();
+    });
 
     const api = new PermaAPI(String(auth.apiKey), PERMA_API_BASE_URL);
 
     isPrivate = Boolean(isPrivate);
     await api.editArchive(guid, {isPrivate});
-    status.message = isPrivate ? "status_archive_made_private" : "status_archive_made_public";
 
-    await archivePullTimeline(); // Will update the timeline once the archive is created
+    await Status.update((status) => {
+      status.message = isPrivate ? "status_archive_made_private" : "status_archive_made_public";
+    });
+
+    await archivePullTimeline(); // Will update the timeline once the archive is updated.
   }
   catch(err) {
-    status.message = "error_toggling_archive_privacy_status";
+    await Status.update((status) => { status.message = "error_toggling_archive_privacy_status"; });
     //console.error(err);
     throw err;
   }
   finally {
-    status.isLoading = false;
-    await status.save();
+    await Status.update((status) => { status.isLoading = false; });
   }
 }

--- a/src/background/authCheck.js
+++ b/src/background/authCheck.js
@@ -8,33 +8,52 @@
 // @ts-check
 
 import { PermaAPI } from "@harvard-lil/perma-js-sdk";
-import { Auth } from "../storage/index.js";
-import { authSignOut } from "./authSignOut.js";
+import { Auth, Status } from "../storage/index.js";
+import { markKeyInvalidOnAuthError } from "./markKeyInvalidOnAuthError.js";
 import { PERMA_API_BASE_URL } from "../constants/index.js";
 
 /**
  * Handler for the `AUTH_CHECK` runtime message:
- * Checks that the Perma API key currently stored is valid (if any). 
- * Clears user data (and throws) otherwise.
- * 
+ * Checks that the Perma API key currently stored is (still) valid.
+ *
+ * The key is an API token, not a login session, so a failed check does not mean "sign out".
+ * We only react to a *definitive* rejection (HTTP 401/403): the key is flagged as invalid
+ * (`auth.isInvalid`) but kept on file, and the popup moves the user to the "invalid key" panel
+ * where they can retry or paste a new key. Folders, archives, and the rest of the session are
+ * left untouched. Transient failures (network errors, timeouts, 5xx) are rethrown without
+ * touching stored state — a dropped connection must never look like a revoked key.
+ *
  * @returns {Promise<void>}
  * @async
  */
 export async function authCheck() {
-  try {
-    const auth = await Auth.fromStorage();
+  const auth = await Auth.fromStorage();
 
-    if (!auth.apiKey || auth.apiKey == "") {
-      throw new Error("No API key provided.");
-    }
-
-    const api = new PermaAPI(String(auth.apiKey), PERMA_API_BASE_URL); // Will throw if API key is invalid
-    await api.pullUser(); // Will throw if API key is invalid
+  if (!auth.apiKey || auth.apiKey == "") {
+    return; // Nothing to check.
   }
-  // If the verification fails, clear any user-related data.
+
+  try {
+    const api = new PermaAPI(String(auth.apiKey), PERMA_API_BASE_URL);
+    await api.pullUser(); // Throws `PermaAPIError` (401/403) if the key is no longer valid.
+
+    // Success. If the key was previously flagged invalid (e.g. the user just hit "Retry", or a
+    // transient 401 has cleared), restore the working session. A plain re-check of an already
+    // valid key changes nothing.
+    if (auth.isInvalid) {
+      auth.isChecked = true;
+      auth.isInvalid = false;
+      auth.lastCheck = new Date();
+      await auth.save();
+
+      await Status.update((status) => { status.message = "status_signed_in"; });
+    }
+  }
   catch(err) {
-    //console.error(err);
-    authSignOut();
+    // Only a definitive auth rejection (401/403) means the key itself is bad; `markKeyInvalidOnAuthError`
+    // flags it. Everything else (network errors, timeouts, 5xx) is transient and left untouched, for
+    // the next check (or a manual retry) to resolve.
+    await markKeyInvalidOnAuthError(err);
     throw err;
   }
 }

--- a/src/background/authSignIn.js
+++ b/src/background/authSignIn.js
@@ -49,6 +49,7 @@ export async function authSignIn(apiKey) {
   }
   finally {
     auth.lastCheck = new Date();
+    auth.isInvalid = false; // A fresh sign-in attempt always supersedes a prior "invalid key" state.
 
     await Status.update((status) => { status.isLoading = false; });
     await auth.save();

--- a/src/background/authSignIn.js
+++ b/src/background/authSignIn.js
@@ -22,14 +22,14 @@ import { PERMA_API_BASE_URL } from "../constants/index.js";
  * @async
  */
 export async function authSignIn(apiKey) {
-  const status = await Status.fromStorage();
   const auth = await Auth.fromStorage();
 
   try {
-    status.isLoading = true;
-    status.message = "status_in_progress";
-    status.lastLoadingInit = new Date();
-    await status.save();
+    await Status.update((status) => {
+      status.isLoading = true;
+      status.message = "status_in_progress";
+      status.lastLoadingInit = new Date();
+    });
 
     const api = new PermaAPI(String(apiKey), PERMA_API_BASE_URL); // Will throw if API key is invalid
     await api.pullUser(); // Will throw if API key is invalid
@@ -37,21 +37,20 @@ export async function authSignIn(apiKey) {
     auth.apiKey = apiKey;
     auth.isChecked = true;
 
-    status.message = "status_signed_in";
+    await Status.update((status) => { status.message = "status_signed_in"; });
   }
   catch(err) {
     auth.apiKey = "";
     auth.isChecked = false;
 
-    status.message = "error_verifying_api_key";
+    await Status.update((status) => { status.message = "error_verifying_api_key"; });
     //console.log(err);
     throw err;
   }
   finally {
-    status.isLoading = false;
     auth.lastCheck = new Date();
 
-    await status.save();
+    await Status.update((status) => { status.isLoading = false; });
     await auth.save();
   }
 }

--- a/src/background/authSignOut.js
+++ b/src/background/authSignOut.js
@@ -31,6 +31,8 @@ export async function authSignOut() {
   await Status.update((status) => {
     status.isLoading = false;
     status.lastLoadingInit = null;
+    status.captureGuid = "";
+    status.captureStep = 0;
     status.message = "status_signed_out";
   });
 }

--- a/src/background/authSignOut.js
+++ b/src/background/authSignOut.js
@@ -26,9 +26,11 @@ export async function authSignOut() {
   const archives = await Archives.fromStorage();
   await archives.reset();
 
-  const status = await Status.fromStorage();
-  await status.reset();
-
-  status.message = "status_signed_out";
-  await status.save();
+  // Reset "status" through the serialized updater so a concurrent capture poll / cleanup can't
+  // re-populate it right after we wipe it.
+  await Status.update((status) => {
+    status.isLoading = false;
+    status.lastLoadingInit = null;
+    status.message = "status_signed_out";
+  });
 }

--- a/src/background/foldersPick.js
+++ b/src/background/foldersPick.js
@@ -3,60 +3,88 @@
  * @module background/foldersPick
  * @author The Harvard Library Innovation Lab
  * @license MIT
- * @description Handler for the `FOLDERS_PICK` runtime message.
+ * @description Handler for the `FOLDERS_PICK_ONE` runtime message.
  */
 // @ts-check
 
 import { PermaAPI } from "@harvard-lil/perma-js-sdk";
-import { Status, Folders } from "../storage/index.js";
+import { Auth, Folders } from "../storage/index.js";
+import { PERMA_API_BASE_URL } from "../constants/index.js";
 
 /**
- * Handler for the `FOLDERS_PICK` runtime message: 
- * Sets `appState.currentFolder`.
- * Stores the default folder id for future archives. 
- * 
- * @param {?number} [folderId=null]
+ * Maps `PermaFolder` objects from the API into the lightweight option shape stored in
+ * `Folders.levels`. Read-only folders are dropped: they can't be capture targets.
+ *
+ * @param {Array} permaFolders - `PermaFolder[]` as returned by the API.
+ * @returns {Array<{id: number, name: string, hasChildren: boolean}>}
+ */
+export function toFolderOptions(permaFolders) {
+  return permaFolders
+    .filter((folder) => folder.read_only !== true)
+    .map((folder) => ({
+      id: folder.id,
+      name: folder.name,
+      hasChildren: Boolean(folder.has_children),
+    }));
+}
+
+/**
+ * Selects a folder at a given cascade level, mutating `folders` in place (does not save):
+ * - Sets it as the current capture target (`pick`) and truncates any deeper selection.
+ * - If the folder has children, lazily fetches them and adds the next cascade level.
+ * - An empty `folderId` clears the selection at this level ("file in the parent folder").
+ *
+ * Shared by `foldersPullList` (to default-select the first top-level folder) and `foldersPick`.
+ *
+ * @param {Folders} folders - Folders storage object to mutate.
+ * @param {PermaAPI} api - Authenticated API instance, used to fetch children on demand.
+ * @param {number} level - Cascade level being changed (0 = top-level).
+ * @param {?(number|string)} folderId - Folder selected at this level, or empty to clear it.
+ * @returns {Promise<void>}
  * @async
  */
-export async function foldersPick(folderId = null) {
-  const status = await Status.fromStorage();
+export async function selectFolder(folders, api, level, folderId) {
+  const levels = folders.levels;
+
+  // Empty selection: "use the parent folder". Drop this selection and any deeper level.
+  if (!folderId) {
+    folders.path = folders.path.slice(0, level);
+    folders.pick = folders.path.length ? folders.path[folders.path.length - 1] : null;
+    folders.levels = levels.slice(0, level + 1);
+    return;
+  }
+
+  folderId = parseInt(folderId);
+  folders.path = [...folders.path.slice(0, level), folderId];
+  folders.pick = folderId;
+
+  // Reveal the next cascade level only if the chosen folder actually has children.
+  const option = (levels[level] || []).find((o) => o.id === folderId);
+
+  if (option && option.hasChildren) {
+    const children = await api.pullFolderChildren(folderId, 300);
+    folders.levels = [...levels.slice(0, level + 1), toFolderOptions(children.objects)];
+  }
+  else {
+    folders.levels = levels.slice(0, level + 1);
+  }
+}
+
+/**
+ * Handler for the `FOLDERS_PICK_ONE` runtime message:
+ * Updates the folder cascade when the user changes a selection at a given level.
+ *
+ * @param {number} level - Cascade level being changed (0 = top-level).
+ * @param {?(number|string)} folderId - Folder selected at this level, or empty to clear it.
+ * @returns {Promise<void>}
+ * @async
+ */
+export async function foldersPick(level = 0, folderId = null) {
+  const auth = await Auth.fromStorage();
   const folders = await Folders.fromStorage();
 
-  try {
-    // If a `folderId` was passed:
-    if (folderId) {
-      // Validate (will throw if `folderId` is not a suitable folder id.)
-      new PermaAPI().validateFolderId(folderId);
-      folderId = parseInt(String(folderId));
-    
-      // Check that folderId exists in available folders
-      let found = false;
-      for (let folder of folders.available) {
-        if (folder.id === folderId) {
-          found = true;
-          break;
-        }
-      }
+  const api = new PermaAPI(String(auth.apiKey), PERMA_API_BASE_URL);
+  await selectFolder(folders, api, parseInt(level), folderId);
 
-      if (found == false) {
-        throw new Error("`folderId` does not match a folder the user has write access to.");
-      }
-
-    }
-    // Make sure it's `null` otherwise (no default)
-    else {
-      folderId = null;
-    }
-
-    folders.pick = folderId;
-  }
-  catch(err) {
-    status.message = "error_picking_folder";
-    console.error(err);
-    throw err;
-  }
-  finally {
-    await status.save();
-    await folders.save();
-  }
+  await folders.save();
 }

--- a/src/background/foldersPullList.js
+++ b/src/background/foldersPullList.js
@@ -9,14 +9,16 @@
 
 import { PermaAPI } from "@harvard-lil/perma-js-sdk";
 import { Auth, Folders } from "../storage/index.js";
+import { selectFolder, toFolderOptions } from "./foldersPick.js";
 import { PERMA_API_BASE_URL } from "../constants/index.js";
 
 /**
  * Handler for the `FOLDERS_PULL_LIST` runtime message:
- * Pulls and stores the list of all the folders the user can write into, sorted hierarchically.
- * 
- * See `storage.Folders.#available` for information regarding the expected format.
- * 
+ * Loads the user's top-level folders into the first cascade level, then restores the previously
+ * selected folder path if it still exists (so the choice persists across popup opens), falling
+ * back to the first top-level folder otherwise. Deeper folders are fetched lazily, only along the
+ * restored path (see `foldersPick`), so this stays an O(depth) operation regardless of tree size.
+ *
  * @returns {Promise<void>}
  * @async
  */
@@ -24,80 +26,31 @@ export async function foldersPullList() {
   const auth = await Auth.fromStorage();
   const folders = await Folders.fromStorage();
 
-  try {
-    const api = new PermaAPI(String(auth.apiKey), PERMA_API_BASE_URL);
+  const api = new PermaAPI(String(auth.apiKey), PERMA_API_BASE_URL);
 
-    const allFolders = [];
-    const topFolder = await api.pullTopLevelFolders();
+  // Remember the previous selection before rebuilding the cascade from a fresh top-level pull.
+  const savedPath = [...folders.path];
 
-    // Pull sorted list of folders the user has access to, in the format expected by Folders.available.
-    for (let folder of topFolder.objects) {
-      allFolders.push({
-        id: folder.id,
-        depth: 0,
-        name: folder.name,
-      });
-      await recursivePull(folder.id, allFolders, api, 1);
+  const topLevel = await api.pullTopLevelFolders(300);
+  folders.levels = [toFolderOptions(topLevel.objects)];
+  folders.path = [];
+  folders.pick = null;
+
+  // Restore the remembered path, level by level, as far as the folders still exist.
+  for (let level = 0; level < savedPath.length; level++) {
+    const options = folders.levels[level];
+
+    if (!options || !options.some((o) => o.id === savedPath[level])) {
+      break; // Folder no longer exists at this level: keep the valid prefix.
     }
 
-    folders.available = allFolders;
-
-    // Check if current value for `folders.pick` is still available.
-    // Default to first folder or null otherwise.
-    if (folders.pick !== null) {
-      let found = false;
-
-      for (let folder of allFolders) {
-        if (folder.id === folders.pick) {
-          found = true;
-          break;
-        }
-      }
-
-      if (found === false) {
-        folders.pick = null;
-      }
-    }
-
-    // If no folder was picked, use the first one available
-    if (folders.pick === null) {
-      if (folders.available && folders.available.length > 0) {
-        folders.pick = folders.available[0]["id"];
-      }
-    }
-
+    await selectFolder(folders, api, level, savedPath[level]);
   }
-  catch(err) {
-    throw err;
+
+  // Nothing restored (no prior selection, or it's gone): default to the first top-level folder.
+  if (folders.pick === null && folders.levels[0].length > 0) {
+    await selectFolder(folders, api, 0, folders.levels[0][0].id);
   }
-  finally {
-    await folders.save();
-  }
-}
 
-/**
- * Utility function to recursively traverse the folders tree and append info to the `folders` array.
- * @param {number} folderId - Folder id of the parent
- * @param {array} folders - Reference to the `folders` array to append to
- * @param {PermaAPI} api - PermaAPI instance to use 
- * @param {number} [depth=1] - Used to represent the nesting level of the folders.
- */
-async function recursivePull(folderId, folders, api, depth=1) {
-  const children = await api.pullFolderChildren(folderId, 300);
-
-  for (let child of children.objects) {
-    if (child.read_only === true) {
-      continue;
-    }
-
-    folders.push({
-      id: child.id,
-      depth: depth,
-      name: child.name,
-    });
-
-    if (child.has_children) {
-      await recursivePull(child.id, folders, api, depth+1);
-    }
-  }
+  await folders.save();
 }

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -12,6 +12,7 @@ import { BROWSER, MESSAGE_IDS } from "../constants/index.js";
 import { archiveCreate } from "./archiveCreate.js";
 import { archiveDelete } from "./archiveDelete.js";
 import { archivePullTimeline } from "./archivePullTimeline.js";
+import { archivePullCaptureStatus } from "./archivePullCaptureStatus.js";
 import { archiveTogglePrivacyStatus } from "./archiveTogglePrivacyStatus.js";
 import { authCheck } from "./authCheck.js";
 import { authSignIn } from "./authSignIn.js";
@@ -141,6 +142,10 @@ function backgroundMessageHandler(message, sender = {}, sendResponse = ()=>{}) {
 
     case MESSAGE_IDS.ARCHIVE_PULL_TIMELINE:
       respondAuthed(archivePullTimeline(), sendResponse);
+      break;
+
+    case MESSAGE_IDS.ARCHIVE_PULL_CAPTURE_STATUS:
+      respondAuthed(archivePullCaptureStatus(), sendResponse);
       break;
 
     case MESSAGE_IDS.ARCHIVE_CREATE_PUBLIC:

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -20,6 +20,30 @@ import { foldersPick } from "./foldersPick.js";
 import { foldersPullList } from "./foldersPullList.js";
 import { statusCleanUp } from "./statusCleanUp.js";
 import { tabSwitch } from "./tabSwitch.js";
+import { PERMA_API_BASE_URL } from "../constants/index.js";
+
+/**
+ * Tags every request the extension makes to the Perma.cc API with a `Perma-Client`
+ * header, so this traffic can be identified in server logs (the SDK has no hook for custom
+ * headers, and `Referer`/`User-Agent` can't be set from `fetch`). All API calls originate in
+ * this service worker via `perma-js-sdk`'s `fetch`, so wrapping `fetch` here covers them all.
+ *
+ * Requests to `api.perma.cc` are covered by `host_permissions`, so this non-safelisted header
+ * is exempt from CORS preflight and won't be stripped.
+ */
+const PERMA_CLIENT = `perma-extension/${BROWSER.runtime.getManifest().version}`;
+const originalFetch = globalThis.fetch;
+globalThis.fetch = (resource, options = {}) => {
+  const url = resource instanceof Request ? resource.url : String(resource);
+
+  if (url.startsWith(PERMA_API_BASE_URL)) {
+    const headers = new Headers(options.headers || (resource instanceof Request ? resource.headers : undefined));
+    headers.set("Perma-Client", PERMA_CLIENT);
+    options = { ...options, headers };
+  }
+
+  return originalFetch(resource, options);
+};
 
 /**
  * Set a 1-minute "alarm" cycle for this service worker.

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -16,6 +16,7 @@ import { archiveTogglePrivacyStatus } from "./archiveTogglePrivacyStatus.js";
 import { authCheck } from "./authCheck.js";
 import { authSignIn } from "./authSignIn.js";
 import { authSignOut } from "./authSignOut.js";
+import { markKeyInvalidOnAuthError } from "./markKeyInvalidOnAuthError.js";
 import { foldersPick } from "./foldersPick.js";
 import { foldersPullList } from "./foldersPullList.js";
 import { statusCleanUp } from "./statusCleanUp.js";
@@ -65,6 +66,40 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
 });
 
 /**
+ * Resolves a handler's promise into the popup's boolean response (`true` on success, `false` on
+ * error).
+ *
+ * @param {Promise<*>} promise
+ * @param {function} sendResponse
+ */
+function respond(promise, sendResponse) {
+  promise
+    .then(() => sendResponse(true))
+    .catch(() => sendResponse(false));
+}
+
+/**
+ * Like `respond`, but for handlers that make authenticated Perma API calls: if the call was
+ * rejected with a 401/403, flag the stored key invalid (`markKeyInvalidOnAuthError`) so the popup
+ * routes to the "invalid key" panel. Without this, a key revoked or rotated between hourly
+ * `authCheck`s would just make every request fail silently.
+ *
+ * `AUTH_SIGN_IN` is intentionally NOT routed through here (it surfaces a bad new key on the sign-in
+ * form), and `AUTH_CHECK` manages its own key state, so both use plain `respond`.
+ *
+ * @param {Promise<*>} promise
+ * @param {function} sendResponse
+ */
+function respondAuthed(promise, sendResponse) {
+  promise
+    .then(() => sendResponse(true))
+    .catch(async (err) => {
+      await markKeyInvalidOnAuthError(err);
+      sendResponse(false);
+    });
+}
+
+/**
  * Handles incoming messages.
  * This function runs for every incoming `runtime` message.
  * See `constants.MESSAGE_IDS` for details regarding the messages handled.
@@ -81,75 +116,51 @@ function backgroundMessageHandler(message, sender = {}, sendResponse = ()=>{}) {
 
   switch (message.messageId) {
     case MESSAGE_IDS.TAB_SWITCH:
-      tabSwitch(message["url"], message["title"])
-        .then(() => sendResponse(true))
-        .catch(() => sendResponse(false));
+      respond(tabSwitch(message["url"], message["title"]), sendResponse);
       break;
 
     case MESSAGE_IDS.AUTH_SIGN_IN:
-      authSignIn(message["apiKey"])
-        .then(() => sendResponse(true))
-        .catch(() => sendResponse(false));
+      respond(authSignIn(message["apiKey"]), sendResponse);
       break;
 
     case MESSAGE_IDS.AUTH_SIGN_OUT:
-      authSignOut()
-        .then(() => sendResponse(true))
-        .catch(() => sendResponse(false));
+      respond(authSignOut(), sendResponse);
       break;
 
     case MESSAGE_IDS.AUTH_CHECK:
-      authCheck()
-        .then(() => sendResponse(true))
-        .catch(() => sendResponse(false));
+      respond(authCheck(), sendResponse);
       break;
 
     case MESSAGE_IDS.FOLDERS_PULL_LIST:
-      foldersPullList()
-        .then(() => sendResponse(true))
-        .catch(() => sendResponse(false));
+      respondAuthed(foldersPullList(), sendResponse);
       break;
 
     case MESSAGE_IDS.FOLDERS_PICK_ONE:
-      foldersPick(message["folderId"])
-        .then(() => sendResponse(true))
-        .catch(() => sendResponse(false));
+      respondAuthed(foldersPick(message["level"], message["folderId"]), sendResponse);
       break;
 
     case MESSAGE_IDS.ARCHIVE_PULL_TIMELINE:
-      archivePullTimeline()
-        .then(() => sendResponse(true))
-        .catch(() => sendResponse(false));
+      respondAuthed(archivePullTimeline(), sendResponse);
       break;
 
     case MESSAGE_IDS.ARCHIVE_CREATE_PUBLIC:
-      archiveCreate(false)
-        .then(() => sendResponse(true))
-        .catch(() => sendResponse(false));
+      respondAuthed(archiveCreate(false), sendResponse);
       break;
 
     case MESSAGE_IDS.ARCHIVE_CREATE_PRIVATE:
-      archiveCreate(true)
-        .then(() => sendResponse(true))
-        .catch(() => sendResponse(false));
+      respondAuthed(archiveCreate(true), sendResponse);
       break;
 
     case MESSAGE_IDS.ARCHIVE_PRIVACY_STATUS_TOGGLE:
-      archiveTogglePrivacyStatus(message["guid"], message["isPrivate"])
-        .then(() => sendResponse(true))
-        .catch(() => sendResponse(false));
+      respondAuthed(archiveTogglePrivacyStatus(message["guid"], message["isPrivate"]), sendResponse);
       break;
 
     case MESSAGE_IDS.ARCHIVE_DELETE:
-      archiveDelete(message["guid"])
-        .then(() => sendResponse(true))
-        .catch(() => sendResponse(false));
+      respondAuthed(archiveDelete(message["guid"]), sendResponse);
       break;
 
     case MESSAGE_IDS.STATUS_CLEAN_UP:
-      statusCleanUp()
-        .then(() => sendResponse(true))
-        .catch(() => sendResponse(false));
+      respond(statusCleanUp(), sendResponse);
       break;
 
     default:

--- a/src/background/markKeyInvalidOnAuthError.js
+++ b/src/background/markKeyInvalidOnAuthError.js
@@ -1,0 +1,60 @@
+/**
+ * perma-extension
+ * @module background/markKeyInvalidOnAuthError
+ * @author The Harvard Library Innovation Lab
+ * @license MIT
+ * @description Shared handling for Perma API auth rejections coming back from any authenticated call.
+ */
+// @ts-check
+
+import { PermaAPIError } from "@harvard-lil/perma-js-sdk";
+import { Auth, Status } from "../storage/index.js";
+
+// Mirror of the SDK's accepted key format (`PermaAPI` constructor): 40 alphanumeric chars.
+const VALID_API_KEY_FORMAT = /^[0-9a-zA-Z]{40}$/;
+
+/**
+ * If `err` means the stored API key is definitively unusable, flag it invalid — the same state the
+ * periodic `authCheck` produces — so the popup routes to the "invalid key" panel instead of failing
+ * silently. Two cases count as definitive:
+ *   - a Perma auth rejection (HTTP 401/403): the server rejected an otherwise well-formed key; or
+ *   - a malformed key on file: the SDK's `PermaAPI` constructor rejects anything that isn't 40
+ *     alphanumeric chars with a plain `Error`, *before* any request goes out (so there's no network
+ *     error to see). Without this branch a corrupt stored key just produces a generic failure.
+ *
+ * This is what catches a key that's revoked or rotated *between* hourly `authCheck`s: any
+ * authenticated request (folders, timeline, create, delete, …) that fails this way trips it, via
+ * the dispatcher in `background/index.js`. The key is kept on file (so it can be shown / retried);
+ * folders, archives, and the timeline are left untouched.
+ *
+ * Only a currently-valid session (`isChecked`) transitions to invalid — if it's already invalid or
+ * signed out, there's nothing to do (and we skip redundant writes). `AUTH_SIGN_IN` deliberately
+ * does NOT go through here: a 401 there is a bad *new* key typed into the sign-in form, which that
+ * handler surfaces on the form itself rather than as a revoked-key panel.
+ *
+ * @param {unknown} err
+ * @returns {Promise<boolean>} `true` if the key was treated as invalid (auth rejection or malformed key).
+ * @async
+ */
+export async function markKeyInvalidOnAuthError(err) {
+  const auth = await Auth.fromStorage();
+
+  const isAuthRejection =
+    err instanceof PermaAPIError && (err.httpStatusCode === 401 || err.httpStatusCode === 403);
+  // Only a non-empty malformed key is "invalid"; an empty key is the signed-out state, not a bad key.
+  const isMalformedKey = Boolean(auth.apiKey) && !VALID_API_KEY_FORMAT.test(String(auth.apiKey));
+
+  if (!isAuthRejection && !isMalformedKey) {
+    return false;
+  }
+
+  if (auth.isChecked) {
+    auth.isChecked = false;
+    auth.isInvalid = true;
+    await auth.save();
+
+    await Status.update((status) => { status.message = "error_api_key_invalid"; });
+  }
+
+  return true;
+}

--- a/src/background/statusCleanUp.js
+++ b/src/background/statusCleanUp.js
@@ -18,23 +18,24 @@ import { Status } from "../storage/index.js";
  * @async
  */
 export async function statusCleanUp() {
-  const status = await Status.fromStorage();
-  let wasUpdated = false;
-  const secondsSinceLastLoadingInit = (new Date() - status.lastLoadingInit) / 1000;
+  // Run the read + conditional write atomically against other status writers (the capture poll,
+  // archive create/delete/toggle) so we never reset a freshly-set loading state from a stale read.
+  await Status.update((status) => {
+    let wasUpdated = false;
+    const secondsSinceLastLoadingInit = (new Date() - status.lastLoadingInit) / 1000;
 
-  // If `isLoading` has been `true` for more than 60 seconds, force it back to false.
-  if (status.isLoading === true && secondsSinceLastLoadingInit > 60) {
-    status.isLoading = false;
-    wasUpdated = true;
-  }
+    // If `isLoading` has been `true` for more than 60 seconds, force it back to false.
+    if (status.isLoading === true && secondsSinceLastLoadingInit > 60) {
+      status.isLoading = false;
+      wasUpdated = true;
+    }
 
-  // If `isLoading` is `false` and the last `lastLoadingInit` happened more than 5 seconds ago, set the current status message to "status_default".
-  if (status.isLoading === false && secondsSinceLastLoadingInit > 5) {
-    status.message = "status_default";
-    wasUpdated = true;
-  }
+    // If `isLoading` is `false` and the last `lastLoadingInit` happened more than 5 seconds ago, set the current status message to "status_default".
+    if (status.isLoading === false && secondsSinceLastLoadingInit > 5) {
+      status.message = "status_default";
+      wasUpdated = true;
+    }
 
-  if (wasUpdated === true) {
-    await status.save();
-  }
+    return wasUpdated; // `false` -> skip the save (nothing changed), avoiding a needless storage event.
+  });
 }

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -38,6 +38,7 @@
  * - `FOLDERS_PULL_LIST`: Request to load the user's top-level folders into the folder cascade.
  * - `FOLDERS_PICK_ONE`: Request to select a folder at a given cascade level (lazily loading its subfolders). Params: `level`, `folderId`.
  * - `ARCHIVE_PULL_TIMELINE`: Request to pull the list of user-owned archives available for the current url.
+ * - `ARCHIVE_PULL_CAPTURE_STATUS`: Request to pull the latest capture-job status for the archive currently being captured.
  * - `ARCHIVE_CREATE_PUBLIC`: Request to create a public archive for a given url.
  * - `ARCHIVE_CREATE_PRIVATE`: Request to create a private archive for a given url.
  * - `ARCHIVE_PRIVACY_STATUS_TOGGLE`: Request to toggle the privacy status of a given archive. Params: `guid`, `isPrivate`.
@@ -58,7 +59,8 @@ export const MESSAGE_IDS = {
   ARCHIVE_CREATE_PRIVATE: 9,
   ARCHIVE_PRIVACY_STATUS_TOGGLE: 10,
   ARCHIVE_DELETE: 11,
-  STATUS_CLEAN_UP: 12
+  STATUS_CLEAN_UP: 12,
+  ARCHIVE_PULL_CAPTURE_STATUS: 13
 };
 
 /**

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -35,8 +35,8 @@
  * - `AUTH_SIGN_IN`: Request to register an API key. Params: `apiKey`.
  * - `AUTH_SIGN_OUT`: Request to remove the currently stored API key.
  * - `AUTH_CHECK`: Request to check that the API currently stored is (still) valid.
- * - `FOLDERS_PULL_LIST`: Request to pull the list of folders the user can create links into.
- * - `FOLDERS_PICK_ONE`: Request to update the "default" target folder. Params: `folderId`.
+ * - `FOLDERS_PULL_LIST`: Request to load the user's top-level folders into the folder cascade.
+ * - `FOLDERS_PICK_ONE`: Request to select a folder at a given cascade level (lazily loading its subfolders). Params: `level`, `folderId`.
  * - `ARCHIVE_PULL_TIMELINE`: Request to pull the list of user-owned archives available for the current url.
  * - `ARCHIVE_CREATE_PUBLIC`: Request to create a public archive for a given url.
  * - `ARCHIVE_CREATE_PRIVATE`: Request to create a private archive for a given url.

--- a/src/popup/components/ArchiveForm.css
+++ b/src/popup/components/ArchiveForm.css
@@ -65,6 +65,28 @@ archive-form > form[action="#sign-in"] a {
   text-align: center;
 }
 
+/* Invalid-key panel */
+archive-form > .invalid-key {
+  padding: 1rem;
+  background-color: var(--main-color);
+  text-align: center;
+}
+
+archive-form > .invalid-key p {
+  font-size: 1rem;
+  font-weight: bold;
+  letter-spacing: var(--letter-spacing);
+  margin-bottom: 1rem;
+  text-align: left;
+  color: var(--opposite-color);
+  overflow-wrap: anywhere;
+}
+
+archive-form > .invalid-key button {
+  display: inline-block;
+  margin: 0 0.25rem;
+}
+
 /* Create archive form */
 archive-form > form[action="#create-archive"] {
   text-align: right;

--- a/src/popup/components/ArchiveForm.css
+++ b/src/popup/components/ArchiveForm.css
@@ -87,6 +87,22 @@ archive-form > .invalid-key button {
   margin: 0 0.25rem;
 }
 
+/* "Page can't be captured" panel */
+archive-form > .not-capturable {
+  padding: 1rem;
+  background-color: var(--main-color);
+}
+
+archive-form > .not-capturable p {
+  font-size: 1rem;
+  font-weight: bold;
+  letter-spacing: var(--letter-spacing);
+  margin: 0;
+  text-align: left;
+  color: var(--opposite-color);
+  overflow-wrap: anywhere;
+}
+
 /* Create archive form */
 archive-form > form[action="#create-archive"] {
   text-align: right;

--- a/src/popup/components/ArchiveForm.css
+++ b/src/popup/components/ArchiveForm.css
@@ -115,6 +115,34 @@ archive-form > form[action="#create-archive"] > fieldset select {
   }
 }
 
+/* Cascade: subfolder selects stack under their parent, slightly indented to read as nesting */
+archive-form > form[action="#create-archive"] > fieldset select.folders-pick-sub {
+  border-top: 1px solid var(--main-color--);
+  border-top-left-radius: 0px;
+  border-top-right-radius: 0px;
+  padding-left: 1.75rem;
+}
+
+/* Breadcrumb: live confirmation of the folder the capture will be filed into */
+archive-form > form[action="#create-archive"] > fieldset .folders-breadcrumb {
+  text-align: left;
+  font-size: 0.9rem;
+  margin: 0 0 0.5rem 0;
+  color: var(--opposite-color--);
+  letter-spacing: var(--letter-spacing);
+  overflow-wrap: anywhere;
+}
+
+archive-form > form[action="#create-archive"] > fieldset .folders-breadcrumb strong {
+  color: var(--action-color);
+}
+
+@media (prefers-color-scheme: dark) {
+  archive-form > form[action="#create-archive"] > fieldset .folders-breadcrumb strong {
+    color: var(--opposite-color);
+  }
+}
+
 archive-form > form[action="#create-archive"] > button {
   display: inline-block;
   border-top-left-radius: 0px;

--- a/src/popup/components/ArchiveForm.js
+++ b/src/popup/components/ArchiveForm.js
@@ -3,23 +3,22 @@
  * @module popup/components/ArchiveForm
  * @author The Harvard Library Innovation Lab
  * @license MIT
- * @description `<archive-form>` custom element. 
+ * @description `<archive-form>` custom element.
  */
 // @ts-check
 import { BROWSER, MESSAGE_IDS } from "../../constants/index.js";
 
 /**
- * Custom Element: `<archive-form>`. 
+ * Custom Element: `<archive-form>`.
  * Allows users to sign-in and create archives.
- * 
+ *
  * Available HTML attributes:
  * - `is-authenticated`: If "true", will show the archive creation form. Will show the sign-in form otherwise.
  * - `is-loading`: If "true", will "block" any form element.
  * - `tab-url`: Url of the current tab.
- * - `folders-list`: JSON-serialized storage entry for "folders.available", if available. Should contain an array of objects (id, depth, name).
- * - `folders-pick`: Id of the folder the user has picked as a default, if any. 
- * 
- * Note: 
+ * - `folders-cascade`: JSON-serialized folder cascade `{ levels, path, pick }` (see `storage.Folders`). Rendered as one `<select>` per opened level.
+ *
+ * Note:
  * - Singleton pattern is enforced. Only 1 element of this type can be present in a given document.
  */
 export class ArchiveForm extends HTMLElement {
@@ -32,7 +31,6 @@ export class ArchiveForm extends HTMLElement {
 
     this.generateSignInForm = this.generateSignInForm.bind(this);
     this.generateCreateArchiveForm = this.generateCreateArchiveForm.bind(this);
-    this.generateFoldersPickOptions = this.generateFoldersPickOptions.bind(this);
 
     this.handleSignInFormSubmit = this.handleSignInFormSubmit.bind(this);
     this.handleFolderSelectChange = this.handleFolderSelectChange.bind(this);
@@ -47,8 +45,7 @@ export class ArchiveForm extends HTMLElement {
       "is-authenticated",
       "is-loading",
       "tab-url",
-      "folders-list",
-      "folders-pick",
+      "folders-cascade",
     ];
   }
 
@@ -80,7 +77,7 @@ export class ArchiveForm extends HTMLElement {
    * On "submit" of the "Sign in" form:
    * - Send `AUTH_SIGN_IN` message to the service worker.
    * - If successful, also call `FOLDERS_PULL_LIST` and `ARCHIVE_PULL_TIMELINE`.
-   * 
+   *
    * @param {Event} e
    */
   async handleSignInFormSubmit(e) {
@@ -103,24 +100,26 @@ export class ArchiveForm extends HTMLElement {
   }
 
   /**
-   * On "change" of the "folders pick" selector.
-   * - Send `FOLDERS_PICK_ONE` message to the service worker.
-   *  
+   * On "change" of one of the cascade's folder selectors.
+   * - Send `FOLDERS_PICK_ONE` message (with the changed level) to the service worker.
+   *
    * @param {Event} e
    */
   async handleFolderSelectChange(e) {
     e.preventDefault();
+    const select = /** @type {HTMLSelectElement} */ (e.target);
 
     BROWSER.runtime.sendMessage({
       messageId: MESSAGE_IDS.FOLDERS_PICK_ONE,
-      folderId: this.querySelector("select[name='folders-pick']")?.value,
+      level: parseInt(select.dataset.level),
+      folderId: select.value, // "" clears this level (file in the parent folder)
     });
   }
 
   /**
    * On "click" of the "Create archive" button.
    * - Send `ARCHIVE_CREATE_PUBLIC` message to the service worker.
-   *  
+   *
    * @param {Event} e
    */
   async handleCreateArchiveClick(e) {
@@ -156,11 +155,10 @@ export class ArchiveForm extends HTMLElement {
       this.handleSignInFormSubmit
     );
 
-    // Create archive form: Pick default folder
-    this.querySelector('form[action="#create-archive"] select')?.addEventListener(
-      "change",
-      this.handleFolderSelectChange
-    );
+    // Create archive form: Pick a folder at any cascade level
+    for (let select of this.querySelectorAll('form[action="#create-archive"] select[data-level]')) {
+      select.addEventListener("change", this.handleFolderSelectChange);
+    }
 
     // Create archive form: Create a public archive
     this.querySelector('form[action="#create-archive"] button')?.addEventListener(
@@ -189,9 +187,9 @@ export class ArchiveForm extends HTMLElement {
 
     return /*html*/`
     <form action="#sign-in">
-      <input type="password" 
-             name="api-key" 
-             id="api-key" 
+      <input type="password"
+             name="api-key"
+             id="api-key"
              minlength="40"
              maxlength="40"
              required
@@ -200,14 +198,14 @@ export class ArchiveForm extends HTMLElement {
 
       <button>${getMessage("sign_in_form_sign_in_button_label")}</button>
 
-      <a href="${getMessage("sign_in_form_sign_in_api_key_help_url")}" 
-        target="_blank" 
+      <a href="${getMessage("sign_in_form_sign_in_api_key_help_url")}"
+        target="_blank"
         rel="noopener noreferrer">
         ${getMessage("sign_in_form_sign_in_api_key_help_caption")}
       </a>
 
-      <a href="${getMessage("sign_in_form_sign_in_guest_link_url") + getAttribute("tab-url")}" 
-        target="_blank" 
+      <a href="${getMessage("sign_in_form_sign_in_guest_link_url") + getAttribute("tab-url")}"
+        target="_blank"
         rel="noopener noreferrer">
         ${getMessage("sign_in_form_sign_in_guest_link_caption")}
       </a>
@@ -218,7 +216,7 @@ export class ArchiveForm extends HTMLElement {
   /**
    * Generates the archive creation form.
    * Will be disabled when visiting "perma.cc/{guid}".
-   * 
+   *
    * @returns {string} HTML
    */
   generateCreateArchiveForm() {
@@ -227,28 +225,31 @@ export class ArchiveForm extends HTMLElement {
 
     const tabUrl = String(getAttribute("tab-url"));
     let forceDisabled = false;
-    
+
     if (tabUrl.match(/^https:\/\/perma\.cc\/[A-Z0-9]{4}\-[A-Z0-9]{4}\/?$/)) {
       forceDisabled = true;
     }
+
+    const cascade = this.getCascade();
+    const hasFolders = cascade.levels.length > 0 && cascade.levels[0].length > 0;
+    const hasTarget = cascade.pick !== null && cascade.pick !== undefined;
+
+    // Don't let the user capture before folders have loaded and a real target is set:
+    // a capture needs a target folder for link accounting.
+    const disableButton = forceDisabled || !hasTarget;
 
     return /*html*/ `
     <form action="#create-archive">
 
       <fieldset>
-        <label for="folders-pick">${getMessage("create_archive_form_select_intro")}</label>
-        <select name="folders-pick"
-                id="folders-pick" 
-                aria-label="${getMessage("create_archive_form_select_label")}"
-                ${forceDisabled ? "disabled" : ""}>
-          <option value="">${getMessage("create_archive_form_select_default")}</option>
-          ${this.generateFoldersPickOptions()}
-        </select>
+        <label>${getMessage("create_archive_form_select_intro")}</label>
+        ${hasFolders ? this.generateBreadcrumb(cascade) : ""}
+        ${hasFolders ? this.generateCascadeSelects(cascade) : this.generateFoldersLoading()}
       </fieldset>
 
       <button aria-label="${getMessage("create_archive_form_button_label")}"
               title="${getMessage("create_archive_form_button_label")}"
-              ${forceDisabled ? "disabled" : ""}>
+              ${disableButton ? "disabled" : ""}>
         ${getMessage("create_archive_form_button_caption")}
       </button>
     </form>
@@ -256,30 +257,125 @@ export class ArchiveForm extends HTMLElement {
   }
 
   /**
-   * Generates a list of `<option>` using the values of the `folders-list` and `folders-pick` attributes.
+   * Reads and parses the `folders-cascade` attribute.
+   * @returns {{levels: Array<Array<{id: number, name: string, hasChildren: boolean}>>, path: number[], pick: ?number}}
+   */
+  getCascade() {
+    const raw = this.getAttribute("folders-cascade");
+
+    if (!raw) {
+      return { levels: [], path: [], pick: null };
+    }
+
+    const parsed = JSON.parse(raw);
+    return {
+      levels: Array.isArray(parsed?.levels) ? parsed.levels : [],
+      path: Array.isArray(parsed?.path) ? parsed.path : [],
+      pick: parsed?.pick ?? null,
+    };
+  }
+
+  /**
+   * Generates one `<select>` per opened cascade level. Levels below the top get a leading
+   * "no subfolder" option (value ""), which targets the parent folder.
+   *
+   * @param {{levels: Array, path: number[]}} cascade
    * @returns {string} HTML
    */
-  generateFoldersPickOptions() {
-    try {
-      let foldersList = this.getAttribute("folders-list");
-      let foldersPick = this.getAttribute("folders-pick");
+  generateCascadeSelects(cascade) {
+    const getMessage = BROWSER.i18n.getMessage;
+    let html = "";
 
-      let html = "";
+    for (let level = 0; level < cascade.levels.length; level++) {
+      const options = cascade.levels[level];
 
-      for (let folder of JSON.parse(foldersList)) {
-        let selected = foldersPick && parseInt(foldersPick) === folder?.id ? "selected" : "";
-        let name = `${"┄".repeat(folder.depth)} ${folder.name}`;
-
-        html += /*html*/ `
-        <option ${selected} value="${folder?.id}" aria-label="${name}">${name}</option>
-        `;
+      if (!options || options.length === 0) {
+        continue; // Selected folder has no children: nothing to drill into.
       }
 
-      return html;
+      const selectedId = cascade.path[level];
+      let optionsHtml = "";
+
+      // Subfolder selects can be left unset to file directly in the parent folder. While this
+      // select is the active tip (nothing chosen in it yet), its empty option prompts "Choose
+      // subfolder". Once a subfolder below has been picked, the empty option's job becomes "go
+      // back up", so it's labelled with the parent's name (e.g. "[Personal Links]").
+      if (level > 0) {
+        const isUnset = selectedId === undefined || selectedId === null;
+        let placeholderLabel;
+
+        if (isUnset) {
+          placeholderLabel = getMessage("create_archive_form_subfolder_choose");
+        }
+        else {
+          const parentOptions = cascade.levels[level - 1] || [];
+          const parentMatch = parentOptions.find((o) => o.id === parseInt(cascade.path[level - 1]));
+          const parentName = parentMatch ? parentMatch.name : "";
+          placeholderLabel = getMessage("create_archive_form_subfolder_parent", [parentName]);
+        }
+
+        optionsHtml += /*html*/ `<option value="" ${isUnset ? "selected" : ""}>${placeholderLabel}</option>`;
+      }
+
+      for (let option of options) {
+        const selected = parseInt(selectedId) === option.id ? "selected" : "";
+        // Mark folders that can be drilled into further.
+        const marker = option.hasChildren ? " " + getMessage("create_archive_form_folder_has_children") : "";
+        optionsHtml += /*html*/ `<option value="${option.id}" ${selected} aria-label="${option.name}">${option.name}${marker}</option>`;
+      }
+
+      html += /*html*/ `
+        <select data-level="${level}"
+                class="folders-pick${level > 0 ? " folders-pick-sub" : ""}"
+                aria-label="${getMessage("create_archive_form_select_label")}">
+          ${optionsHtml}
+        </select>`;
     }
-    catch(err) {
+
+    return html;
+  }
+
+  /**
+   * Generates a breadcrumb showing the folder the capture will be filed into.
+   *
+   * @param {{levels: Array, path: number[]}} cascade
+   * @returns {string} HTML
+   */
+  generateBreadcrumb(cascade) {
+    const getMessage = BROWSER.i18n.getMessage;
+    const names = [];
+
+    for (let level = 0; level < cascade.path.length; level++) {
+      const options = cascade.levels[level] || [];
+      const match = options.find((o) => o.id === parseInt(cascade.path[level]));
+
+      if (match) {
+        names.push(match.name);
+      }
+    }
+
+    if (names.length === 0) {
       return "";
     }
+
+    return /*html*/ `
+      <p class="folders-breadcrumb">
+        ${getMessage("create_archive_form_breadcrumb_intro")}
+        <strong>${names.join(" › ")}</strong>
+      </p>`;
   }
-} 
+
+  /**
+   * Generates a disabled placeholder select shown while top-level folders are still loading.
+   * @returns {string} HTML
+   */
+  generateFoldersLoading() {
+    const getMessage = BROWSER.i18n.getMessage;
+
+    return /*html*/ `
+      <select class="folders-pick" disabled aria-label="${getMessage("create_archive_form_folders_loading")}">
+        <option>${getMessage("create_archive_form_folders_loading")}</option>
+      </select>`;
+  }
+}
 customElements.define('archive-form', ArchiveForm);

--- a/src/popup/components/ArchiveForm.js
+++ b/src/popup/components/ArchiveForm.js
@@ -13,7 +13,10 @@ import { BROWSER, MESSAGE_IDS } from "../../constants/index.js";
  * Allows users to sign-in and create archives.
  *
  * Available HTML attributes:
- * - `is-authenticated`: If "true", will show the archive creation form. Will show the sign-in form otherwise.
+ * - `auth-state`: One of "valid" | "invalid" | "signedout". Drives which form is shown:
+ *   "valid" -> archive creation form, "invalid" -> "invalid key" panel (retry / update key),
+ *   "signedout" (or unset) -> sign-in form.
+ * - `key-hint`: Last few characters of the stored API key, shown in the "invalid key" panel.
  * - `is-loading`: If "true", will "block" any form element.
  * - `tab-url`: Url of the current tab.
  * - `folders-cascade`: JSON-serialized folder cascade `{ levels, path, pick }` (see `storage.Folders`). Rendered as one `<select>` per opened level.
@@ -30,11 +33,21 @@ export class ArchiveForm extends HTMLElement {
     super();
 
     this.generateSignInForm = this.generateSignInForm.bind(this);
+    this.generateInvalidKeyPanel = this.generateInvalidKeyPanel.bind(this);
     this.generateCreateArchiveForm = this.generateCreateArchiveForm.bind(this);
 
     this.handleSignInFormSubmit = this.handleSignInFormSubmit.bind(this);
+    this.handleRetryClick = this.handleRetryClick.bind(this);
+    this.handleUpdateKeyClick = this.handleUpdateKeyClick.bind(this);
     this.handleFolderSelectChange = this.handleFolderSelectChange.bind(this);
     this.handleCreateArchiveClick = this.handleCreateArchiveClick.bind(this);
+
+    /**
+     * When `true`, show the sign-in form even though `auth-state` is "invalid" — set by the
+     * "Update key" button so the user can paste a replacement key. Reset on leaving the invalid state.
+     * @type {boolean}
+     */
+    this.showSignIn = false;
   }
 
   /**
@@ -42,7 +55,8 @@ export class ArchiveForm extends HTMLElement {
    */
   static get observedAttributes() {
     return [
-      "is-authenticated",
+      "auth-state",
+      "key-hint",
       "is-loading",
       "tab-url",
       "folders-cascade",
@@ -94,9 +108,58 @@ export class ArchiveForm extends HTMLElement {
     });
 
     if (signedIn === true) {
-      BROWSER.runtime.sendMessage({ messageId: MESSAGE_IDS.FOLDERS_PULL_LIST });
-      BROWSER.runtime.sendMessage({ messageId: MESSAGE_IDS.ARCHIVE_PULL_TIMELINE });
+      await this.sendRuntimeMessage(MESSAGE_IDS.FOLDERS_PULL_LIST);
+      await this.sendRuntimeMessage(MESSAGE_IDS.ARCHIVE_PULL_TIMELINE);
     }
+  }
+
+  /**
+   * On "click" of the "Retry" button in the invalid-key panel:
+   * - Send `AUTH_CHECK` to re-validate the stored key. If it now succeeds (transient 401 cleared,
+   *   or key re-enabled), the service worker restores the session and the UI re-renders.
+   * - On success, also re-pull folders and timeline — they were never loaded while the key was
+   *   invalid, so the recovered archive form would otherwise come up empty (mirrors sign-in).
+   *
+   * @param {Event} e
+   */
+  async handleRetryClick(e) {
+    e.preventDefault();
+
+    const recovered = await new Promise((resolve) => {
+      BROWSER.runtime.sendMessage(
+        { messageId: MESSAGE_IDS.AUTH_CHECK },
+        (response) => resolve(response)
+      );
+    });
+
+    if (recovered === true) {
+      await this.sendRuntimeMessage(MESSAGE_IDS.FOLDERS_PULL_LIST);
+      await this.sendRuntimeMessage(MESSAGE_IDS.ARCHIVE_PULL_TIMELINE);
+    }
+  }
+
+  /**
+   * Sends a runtime message and resolves when the service worker responds.
+   *
+   * @param {number} messageId
+   * @returns {Promise<*>}
+   */
+  async sendRuntimeMessage(messageId) {
+    return await new Promise((resolve) => {
+      BROWSER.runtime.sendMessage({ messageId }, (response) => resolve(response));
+    });
+  }
+
+  /**
+   * On "click" of the "Update key" button in the invalid-key panel:
+   * - Reveal the sign-in form so the user can paste a replacement key (without losing their data).
+   *
+   * @param {Event} e
+   */
+  handleUpdateKeyClick(e) {
+    e.preventDefault();
+    this.showSignIn = true;
+    this.renderInnerHTML();
   }
 
   /**
@@ -133,15 +196,26 @@ export class ArchiveForm extends HTMLElement {
    */
   renderInnerHTML() {
     const getAttribute = this.getAttribute.bind(this);
+    const authState = getAttribute("auth-state");
+
+    // Leaving the invalid state clears the "update key" override, so the panel (not the sign-in
+    // form) is what shows if the key becomes invalid again later.
+    if (authState !== "invalid") {
+      this.showSignIn = false;
+    }
 
     //
     // [1] Prepare and inject template
     //
-    // If authenticated: Archive creation form
-    if (getAttribute("is-authenticated") === "true") {
+    // Valid key: Archive creation form
+    if (authState === "valid") {
       this.innerHTML = this.generateCreateArchiveForm();
     }
-    // If not authenticated: Sign-in form
+    // Invalid key (and not updating it): "invalid key" panel.
+    else if (authState === "invalid" && !this.showSignIn) {
+      this.innerHTML = this.generateInvalidKeyPanel();
+    }
+    // Signed out, or updating an invalid key: Sign-in form.
     else {
       this.innerHTML = this.generateSignInForm();
     }
@@ -153,6 +227,16 @@ export class ArchiveForm extends HTMLElement {
     this.querySelector('form[action="#sign-in"]')?.addEventListener(
       "submit",
       this.handleSignInFormSubmit
+    );
+
+    // Invalid-key panel: Retry / Update key
+    this.querySelector('button[data-action="retry"]')?.addEventListener(
+      "click",
+      this.handleRetryClick
+    );
+    this.querySelector('button[data-action="update-key"]')?.addEventListener(
+      "click",
+      this.handleUpdateKeyClick
     );
 
     // Create archive form: Pick a folder at any cascade level
@@ -187,11 +271,12 @@ export class ArchiveForm extends HTMLElement {
 
     return /*html*/`
     <form action="#sign-in">
+      <!-- No client-side length constraints: a wrong-format key should reach authSignIn and
+           surface the same "couldn't verify your key" error as a well-formed-but-rejected one,
+           rather than being silently blocked by HTML5 validation with no feedback. -->
       <input type="password"
              name="api-key"
              id="api-key"
-             minlength="40"
-             maxlength="40"
              required
              aria-label="${getMessage("sign_in_form_api_key_input_label")}"
              placeholder="${getMessage("sign_in_form_api_key_input_label")}"/>
@@ -210,6 +295,27 @@ export class ArchiveForm extends HTMLElement {
         ${getMessage("sign_in_form_sign_in_guest_link_caption")}
       </a>
     </form>
+    `;
+  }
+
+  /**
+   * Generates the "invalid key" panel, shown when the stored API key was rejected (401/403).
+   * Keeps the user's data and offers to re-check the key ("Retry") or replace it ("Update key").
+   * @returns {string} HTML
+   */
+  generateInvalidKeyPanel() {
+    const getMessage = BROWSER.i18n.getMessage;
+    const keyHint = this.getAttribute("key-hint");
+
+    return /*html*/`
+    <div class="invalid-key">
+      <p>${keyHint
+        ? getMessage("invalid_key_panel_intro_with_hint", [keyHint])
+        : getMessage("invalid_key_panel_intro")}</p>
+
+      <button data-action="retry">${getMessage("invalid_key_panel_retry_button_label")}</button>
+      <button data-action="update-key">${getMessage("invalid_key_panel_update_button_label")}</button>
+    </div>
     `;
   }
 

--- a/src/popup/components/ArchiveForm.js
+++ b/src/popup/components/ArchiveForm.js
@@ -9,6 +9,55 @@
 import { BROWSER, MESSAGE_IDS } from "../../constants/index.js";
 
 /**
+ * Determines whether a given tab URL can be captured by Perma.
+ *
+ * Perma captures happen server-side, so only public http(s) pages can be archived. This rules out:
+ * - browser-internal / non-web pages (`about:blank`, `chrome://`, `file://`, `data:`, …),
+ * - addresses Perma's servers can't reach (localhost, private IP ranges, bare intranet hostnames),
+ * - and — for now — perma.cc links themselves (re-capturing a Perma Link isn't allowed).
+ *
+ * The local check can't do DNS resolution the way Perma's servers do, so the "private address"
+ * matching is a best-effort approximation of what the server will refuse.
+ *
+ * @param {string} tabUrl
+ * @returns {boolean}
+ */
+export function isCapturableUrl(tabUrl) {
+  let url;
+  try {
+    url = new URL(tabUrl);
+  } catch {
+    return false; // Empty / malformed (e.g. the popup's initial unset "tab-url").
+  }
+
+  // Server-side capture needs a public http(s) page.
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return false;
+  }
+
+  const host = url.hostname;
+
+  // Perma Links themselves can't be re-captured.
+  if (host === "perma.cc" || host.endsWith(".perma.cc")) {
+    return false;
+  }
+
+  // Addresses Perma's servers can't reach.
+  const isLocal =
+    host === "localhost" ||
+    host.endsWith(".local") ||
+    !host.includes(".") || // Bare intranet hostnames, e.g. "wiki".
+    host === "0.0.0.0" ||
+    host === "[::1]" ||
+    /^127\./.test(host) ||
+    /^10\./.test(host) ||
+    /^192\.168\./.test(host) ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(host);
+
+  return !isLocal;
+}
+
+/**
  * Custom Element: `<archive-form>`.
  * Allows users to sign-in and create archives.
  *
@@ -34,6 +83,7 @@ export class ArchiveForm extends HTMLElement {
 
     this.generateSignInForm = this.generateSignInForm.bind(this);
     this.generateInvalidKeyPanel = this.generateInvalidKeyPanel.bind(this);
+    this.generateNotCapturablePanel = this.generateNotCapturablePanel.bind(this);
     this.generateCreateArchiveForm = this.generateCreateArchiveForm.bind(this);
 
     this.handleSignInFormSubmit = this.handleSignInFormSubmit.bind(this);
@@ -207,9 +257,12 @@ export class ArchiveForm extends HTMLElement {
     //
     // [1] Prepare and inject template
     //
-    // Valid key: Archive creation form
+    // Valid key: Archive creation form — unless the current page can't be captured, in which case
+    // we explain why instead of offering a button that would only fail server-side.
     if (authState === "valid") {
-      this.innerHTML = this.generateCreateArchiveForm();
+      this.innerHTML = isCapturableUrl(String(getAttribute("tab-url")))
+        ? this.generateCreateArchiveForm()
+        : this.generateNotCapturablePanel();
     }
     // Invalid key (and not updating it): "invalid key" panel.
     else if (authState === "invalid" && !this.showSignIn) {
@@ -320,21 +373,29 @@ export class ArchiveForm extends HTMLElement {
   }
 
   /**
+   * Generates the "page can't be captured" panel, shown for non-capturable tabs (browser-internal
+   * pages, private addresses, perma.cc links). See `isCapturableUrl`. The current URL itself is
+   * already shown in `<app-header>`, so this panel only needs to explain why there's no button.
+   *
+   * @returns {string} HTML
+   */
+  generateNotCapturablePanel() {
+    const getMessage = BROWSER.i18n.getMessage;
+
+    return /*html*/ `
+    <div class="not-capturable">
+      <p>${getMessage("not_capturable_panel_message")}</p>
+    </div>
+    `;
+  }
+
+  /**
    * Generates the archive creation form.
-   * Will be disabled when visiting "perma.cc/{guid}".
    *
    * @returns {string} HTML
    */
   generateCreateArchiveForm() {
     const getMessage = BROWSER.i18n.getMessage;
-    const getAttribute = this.getAttribute.bind(this);
-
-    const tabUrl = String(getAttribute("tab-url"));
-    let forceDisabled = false;
-
-    if (tabUrl.match(/^https:\/\/perma\.cc\/[A-Z0-9]{4}\-[A-Z0-9]{4}\/?$/)) {
-      forceDisabled = true;
-    }
 
     const cascade = this.getCascade();
     const hasFolders = cascade.levels.length > 0 && cascade.levels[0].length > 0;
@@ -342,7 +403,7 @@ export class ArchiveForm extends HTMLElement {
 
     // Don't let the user capture before folders have loaded and a real target is set:
     // a capture needs a target folder for link accounting.
-    const disableButton = forceDisabled || !hasTarget;
+    const disableButton = !hasTarget;
 
     return /*html*/ `
     <form action="#create-archive">

--- a/src/popup/components/ArchiveTimeline.css
+++ b/src/popup/components/ArchiveTimeline.css
@@ -1,9 +1,7 @@
 archive-timeline {
   display: block;
   grid-area: main-bottom;
-  height: 100%;
   overflow-x: hidden;
-  overflow-y: auto;
 
   opacity: 0;
   animation: archive-timeline-fade-in 0.35s normal forwards ease-in-out;
@@ -34,7 +32,7 @@ archive-timeline h3 {
 /* Empty message */
 archive-timeline aside.empty {
   display: flex;
-  height: 100%;
+  min-height: 6rem;
   border-top: 1px solid var(--main-color-);
 }
 

--- a/src/popup/components/ArchiveTimeline.js
+++ b/src/popup/components/ArchiveTimeline.js
@@ -18,7 +18,8 @@ import { BROWSER } from "../../constants/index.js";
  * - Use `addArchives()` to feed this component an array of archive objects (See: PermaArchive objects from `perma-js-sdk`).
  * 
  * Available HTML attributes:
- * - `is-authenticated`: If not "true", this component is hidden.
+ * - `auth-state`: One of "valid" | "invalid" | "signedout". Hidden only when "signedout"; the
+ *   already-fetched timeline stays visible while a key is invalid so the user keeps their context.
  * - `is-loading`: If "true", disables all nested form elements.
  * 
  * Note: 
@@ -29,7 +30,7 @@ export class ArchiveTimeline extends HTMLElement {
    * Defines which HTML attributes should be observed by `attributeChangedCallback`.
    */
   static get observedAttributes() {
-    return ["is-authenticated", "is-loading"];
+    return ["auth-state", "is-loading"];
   }
 
   /**
@@ -107,16 +108,17 @@ export class ArchiveTimeline extends HTMLElement {
     // [1] Assemble and inject template 
     //
 
-    // If not authenticated:
+    // If there is no key on file yet (signed out, or auth state not hydrated):
     // - Element should be `aria-hidden`
     // - InnerHTML should be empty.
-    if (getAttribute("is-authenticated") !== "true") {
+    const authState = getAttribute("auth-state");
+    if (authState !== "valid" && authState !== "invalid") {
       setAttribute("aria-hidden", "true");
       this.innerHTML = ``;
       return;
     }
 
-    // If authenticated:
+    // If there is a key on file (valid or invalid):
     // - This element should behave like a list
     // - This element should only accept `<archive-timeline-item>` and `<h3>` as direct children (filter everything else out)
     // - This element should display a message if there are no archives to display (inject it)

--- a/src/popup/components/ArchiveTimeline.js
+++ b/src/popup/components/ArchiveTimeline.js
@@ -97,6 +97,28 @@ export class ArchiveTimeline extends HTMLElement {
   }
 
   /**
+   * Reflects the progress of an in-progress capture on its matching `<archive-timeline-item>`.
+   * Sets `capture-progress` (a 0–100 percentage) on the item whose `guid` matches, and clears
+   * it on all others. Perma capture jobs report ~5 steps, so progress is `step / 5`.
+   *
+   * @param {string} guid - GUID of the archive being captured, or "" if none.
+   * @param {number} step - Capture steps completed (`PermaCaptureJob.step_count`).
+   */
+  setActiveCapture(guid, step) {
+    const TOTAL_STEPS = 5;
+    const percent = Math.max(0, Math.min(100, Math.round((Number(step) / TOTAL_STEPS) * 100)));
+
+    for (let item of this.querySelectorAll("archive-timeline-item")) {
+      if (guid && item.getAttribute("guid") === guid) {
+        item.setAttribute("capture-progress", String(percent));
+      }
+      else {
+        item.removeAttribute("capture-progress");
+      }
+    }
+  }
+
+  /**
    * Assembles a template and injects it into `innerHTML`.
    */
   renderInnerHTML() {

--- a/src/popup/components/ArchiveTimelineItem.css
+++ b/src/popup/components/ArchiveTimelineItem.css
@@ -55,6 +55,26 @@ archive-timeline-item > a span {
   letter-spacing: var(--letter-spacing);
 }
 
+/* Capture progress bar (shown while a capture is pending) */
+archive-timeline-item > a span.capture-progress {
+  display: block;
+  width: 100%;
+  height: 0.35rem;
+  margin-top: 0.4rem;
+  border-radius: 0.35rem;
+  background-color: var(--main-color-);
+  overflow: hidden;
+}
+
+archive-timeline-item > a span.capture-progress .capture-progress-fill {
+  display: block;
+  height: 100%;
+  min-width: 0.35rem;
+  border-radius: 0.35rem;
+  background-color: var(--action-color-);
+  transition: width 0.4s ease-in-out;
+}
+
 archive-timeline-item > button {
   padding: 0.35rem;
   padding-top: 0.55rem;

--- a/src/popup/components/ArchiveTimelineItem.js
+++ b/src/popup/components/ArchiveTimelineItem.js
@@ -39,8 +39,8 @@ export class ArchiveTimelineItem extends HTMLElement {
   /**
    * Defines which HTML attributes should be observed by `attributeChangedCallback`.
    */
-  static get observedAttributes() { 
-    return ["guid", "creation-timestamp", "capture-status"];
+  static get observedAttributes() {
+    return ["guid", "creation-timestamp", "capture-status", "capture-progress"];
   }
 
   /**
@@ -117,14 +117,33 @@ export class ArchiveTimelineItem extends HTMLElement {
       linkCaption = getMessage(`archive_timeline_item_capture_${captureStatus}`);
     }
 
+    // While a capture is pending, show a progress bar driven by the `capture-progress` attribute
+    // (0–100, set from the capture job's step count). See `ArchiveTimeline.setActiveCapture`.
+    let progressBarHtml = "";
+
+    if (captureStatus === "pending") {
+      let progress = parseInt(getAttribute("capture-progress"));
+      progress = Number.isNaN(progress) ? 0 : Math.max(0, Math.min(100, progress));
+
+      progressBarHtml = /*html*/`
+        <span class="capture-progress"
+              role="progressbar"
+              aria-valuenow="${progress}"
+              aria-valuemin="0"
+              aria-valuemax="100">
+          <span class="capture-progress-fill" style="width: ${progress}%"></span>
+        </span>`;
+    }
+
     this.innerHTML = /*html*/`
-      <a href="${getMessage("perma_base_url")}${guid}" 
-         target="_blank" 
+      <a href="${getMessage("perma_base_url")}${guid}"
+         target="_blank"
          rel="noopener noreferrer"
          title="${archiveLinkLabel}"
          aria-label="${archiveLinkLabel}">
          <strong>${guid}</strong><br>
          <span>${linkCaption}</span>
+         ${progressBarHtml}
       </a>
 
       <button aria-label="${archiveCopyLabel}" title="${archiveCopyLabel}">

--- a/src/popup/components/StatusBar.css
+++ b/src/popup/components/StatusBar.css
@@ -1,5 +1,7 @@
 status-bar {
   grid-area: footer;
+  /* Stick to the bottom of the popup when content is short; scroll with content when it's tall. */
+  margin-top: auto;
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/src/popup/components/StatusBar.js
+++ b/src/popup/components/StatusBar.js
@@ -14,7 +14,8 @@ import { BROWSER, MESSAGE_IDS } from "../../constants/index.js";
  * Informs users on the extension's current state (is loading, error messages ...).
  * 
  * Available HTML attributes:
- * - `is-authenticated`: If "true", will show the "Sign out" button if not loading.
+ * - `auth-state`: One of "valid" | "invalid" | "signedout". The "Sign out" button shows whenever a
+ *   key is on file ("valid" or "invalid") and not loading, so an invalid key can still be cleared.
  * - `is-loading`: If "true", will show a loading spinner.
  * - `message`: Should be a key accessible via `browser.i18n`.
  * 
@@ -35,7 +36,7 @@ export class StatusBar extends HTMLElement {
    * Defines which HTML attributes should be observed by `attributeChangedCallback`.
    */
   static get observedAttributes() { 
-    return ["is-authenticated", "is-loading", "message"];
+    return ["auth-state", "is-loading", "message"];
   }
 
   /**
@@ -93,8 +94,8 @@ export class StatusBar extends HTMLElement {
          ${getMessage(message)}
       </p>`;
 
-    // Sign-out button (only if authenticated and not loading) 
-    if (getAttribute("is-authenticated") === 'true' && getAttribute("is-loading") !== 'true') {
+    // Sign-out button (whenever a key is on file — valid or invalid — and not loading)
+    if (getAttribute("auth-state") !== 'signedout' && getAttribute("auth-state") !== null && getAttribute("is-loading") !== 'true') {
       html += /*html*/`<button>${getMessage("status_bar_sign_out_button_caption")}</button>`;
     }
 

--- a/src/popup/handlers/onPopupOpen.js
+++ b/src/popup/handlers/onPopupOpen.js
@@ -63,12 +63,9 @@ export async function onPopupOpen(e = null) {
   // [4] If authenticated, send the following messages on schedule: 
   // 
 
-  // `FOLDERS_PULL_LIST` to refresh the list of available folders.
-  // Once + every 20 seconds.
-  sendMessageIfAuth(MESSAGE_IDS.FOLDERS_PULL_LIST)
-  setInterval(async () => {
-    await sendMessageIfAuth(MESSAGE_IDS.FOLDERS_PULL_LIST);
-  }, 20000);
+  // `FOLDERS_PULL_LIST` to populate the folder picker. Once on open: the folder list is
+  // stable within a popup session (it is also refreshed on sign-in).
+  sendMessageIfAuth(MESSAGE_IDS.FOLDERS_PULL_LIST);
 
   // `ARCHIVE_PULL_TIMELINE` to fetch user-created archives for the current tab.
   // Once + every 5 seconds.

--- a/src/popup/handlers/onPopupOpen.js
+++ b/src/popup/handlers/onPopupOpen.js
@@ -10,6 +10,8 @@
 import { BROWSER, MESSAGE_IDS } from "../../constants/index.js";
 import { Status } from "../../storage/Status.js";
 import { Auth } from "../../storage/Auth.js";
+import { CurrentTab } from "../../storage/CurrentTab.js";
+import { Archives } from "../../storage/Archives.js";
 
 import { onStorageUpdate } from "./onStorageUpdate.js";
 
@@ -60,21 +62,34 @@ export async function onPopupOpen(e = null) {
   }
 
   //
-  // [4] If authenticated, send the following messages on schedule: 
-  // 
+  // [4] If authenticated, load data and schedule capture polling.
+  //
 
   // `FOLDERS_PULL_LIST` to populate the folder picker. Once on open: the folder list is
   // stable within a popup session (it is also refreshed on sign-in).
   sendMessageIfAuth(MESSAGE_IDS.FOLDERS_PULL_LIST);
 
-  // `ARCHIVE_PULL_TIMELINE` to fetch user-created archives for the current tab.
-  // Once + every 5 seconds.
-  sendMessageIfAuth(MESSAGE_IDS.ARCHIVE_PULL_TIMELINE)
-  setInterval(async () => {
-    await sendMessageIfAuth(MESSAGE_IDS.ARCHIVE_PULL_TIMELINE);
-  }, 5000);
+  // `ARCHIVE_PULL_TIMELINE` to fetch the user's existing archives for the current tab.
+  // Once on open — the timeline for a url only changes when this user captures it, which we
+  // track separately below.
+  await sendMessageIfAuth(MESSAGE_IDS.ARCHIVE_PULL_TIMELINE);
 
-  // `STATUS_CLEAN_UP` to clean up potential status hangs.
+  // If a capture is already in progress for this page (popup reopened mid-capture, or a
+  // capture started from another client), adopt it so its progress resumes.
+  await adoptInProgressCapture();
+
+  // `ARCHIVE_PULL_CAPTURE_STATUS` polls the lightweight `/v1/capture_jobs/{guid}` endpoint to
+  // drive the progress bar and refresh the timeline when a capture finishes. It only generates
+  // traffic while a capture is actually running (`status.captureGuid` is set) — an idle popup
+  // makes no requests. Matches the 2s cadence the main Perma web app uses.
+  setInterval(async () => {
+    const status = await Status.fromStorage();
+    if (status.captureGuid) {
+      await sendMessageIfAuth(MESSAGE_IDS.ARCHIVE_PULL_CAPTURE_STATUS);
+    }
+  }, 2000);
+
+  // `STATUS_CLEAN_UP` to clean up potential status hangs (local only — no network).
   // Once + every 2.5 seconds.
   sendMessageIfAuth(MESSAGE_IDS.STATUS_CLEAN_UP)
   setInterval(async () => {
@@ -84,11 +99,41 @@ export async function onPopupOpen(e = null) {
 }
 
 /**
- * Sends a given runtime message if user is authenticated.
- * Pulls latest Auth info from storage. 
- * 
- * @param {number} messageId 
+ * If no capture is currently being tracked but the timeline shows a pending capture for the
+ * current tab, start tracking it (so `ARCHIVE_PULL_CAPTURE_STATUS` resumes its progress).
+ *
  * @returns {Promise<void>}
+ * @async
+ */
+async function adoptInProgressCapture() {
+  const status = await Status.fromStorage();
+
+  if (status.captureGuid) {
+    return; // Already tracking a capture.
+  }
+
+  const currentTab = await CurrentTab.fromStorage();
+  const archives = await Archives.fromStorage();
+  const archivesForUrl = archives.byUrl[currentTab.url] || [];
+
+  for (let archive of archivesForUrl) {
+    const primaryCapture = (archive.captures || []).find((c) => c.role === "primary");
+
+    if (primaryCapture && primaryCapture.status === "pending") {
+      status.captureGuid = archive.guid;
+      status.captureStep = 0;
+      await status.save();
+      return;
+    }
+  }
+}
+
+/**
+ * Sends a given runtime message if user is authenticated.
+ * Pulls latest Auth info from storage. Resolves once the service worker has handled the message.
+ *
+ * @param {number} messageId
+ * @returns {Promise<*>}
  * @async
  */
 async function sendMessageIfAuth(messageId) {
@@ -98,5 +143,7 @@ async function sendMessageIfAuth(messageId) {
     return;
   }
 
-  BROWSER.runtime.sendMessage({ messageId });
+  return await new Promise((resolve) => {
+    BROWSER.runtime.sendMessage({ messageId }, (response) => resolve(response));
+  });
 }

--- a/src/popup/handlers/onStorageUpdate.js
+++ b/src/popup/handlers/onStorageUpdate.js
@@ -78,9 +78,18 @@ export async function onStorageUpdate(changes = {}) {
   //
   if (updatedKeys.indexOf(Auth.KEY) > -1) {
     const auth = await Auth.fromStorage();
-    archiveForm?.setAttribute("is-authenticated", auth.isChecked);
-    statusBar?.setAttribute("is-authenticated", auth.isChecked);
-    archiveTimeline?.setAttribute("is-authenticated", auth.isChecked);
+
+    // Tri-state auth, consumed by the components below:
+    // - "valid": signed in with a working key -> archive form, timeline, sign-out button.
+    // - "invalid": key on file but rejected (401/403) -> "invalid key" panel; timeline stays.
+    // - "signedout": no usable key -> sign-in form.
+    const authState = auth.isInvalid ? "invalid" : (auth.isChecked ? "valid" : "signedout");
+
+    archiveForm?.setAttribute("auth-state", authState);
+    // Last 4 chars of the key, shown in the "invalid key" panel so users can tell which key failed.
+    archiveForm?.setAttribute("key-hint", auth.apiKey ? auth.apiKey.slice(-4) : "");
+    statusBar?.setAttribute("auth-state", authState);
+    archiveTimeline?.setAttribute("auth-state", authState);
   }
 
   //

--- a/src/popup/handlers/onStorageUpdate.js
+++ b/src/popup/handlers/onStorageUpdate.js
@@ -100,8 +100,11 @@ export async function onStorageUpdate(changes = {}) {
   if (updatedKeys.indexOf(Folders.KEY) > -1) {
     const folders = await Folders.fromStorage();
 
-    archiveForm?.setAttribute("folders-list", JSON.stringify(folders.available));
-    archiveForm?.setAttribute("folders-pick", folders.pick);
+    archiveForm?.setAttribute("folders-cascade", JSON.stringify({
+      levels: folders.levels,
+      path: folders.path,
+      pick: folders.pick,
+    }));
   }
   
 

--- a/src/popup/handlers/onStorageUpdate.js
+++ b/src/popup/handlers/onStorageUpdate.js
@@ -71,6 +71,9 @@ export async function onStorageUpdate(changes = {}) {
     statusBar?.setAttribute("message", status.message);
 
     archiveTimeline?.setAttribute("is-loading", status.isLoading);
+
+    // Reflect capture progress on the matching timeline item (if a capture is in progress).
+    archiveTimeline?.setActiveCapture(status.captureGuid, status.captureStep);
   }
 
   //
@@ -98,9 +101,13 @@ export async function onStorageUpdate(changes = {}) {
   if (updatedKeys.indexOf(Archives.KEY) > -1) {
     const archives = await Archives.fromStorage();
     const currentTab = await CurrentTab.fromStorage();
+    const status = await Status.fromStorage();
 
     // Add archives for the current url to `<archive-timeline>`
     archiveTimeline.addArchives(archives.byUrl[currentTab.url])
+
+    // Re-apply capture progress: `addArchives` rebuilds the items from scratch.
+    archiveTimeline.setActiveCapture(status.captureGuid, status.captureStep);
   }
 
   //

--- a/src/popup/index.css
+++ b/src/popup/index.css
@@ -60,19 +60,21 @@ body {
   border: var(--body-border-width) solid var(--main-color--);
   background-color: var(--main-color);
   color: var(--opposite-color);
-  overflow: hidden;
 
-  display: grid;
-  grid-template-areas: "header"
-                       "main-top"
-                       "main-bottom"
-                       "footer";
-  grid-template-columns: 1fr;
-  grid-template-rows: 0.75fr repeat(2, 1fr) 3.25rem;
-  grid-column-gap: 0px;
-  grid-row-gap: 0px;
-  
+  /* Scroll the whole popup when its content (e.g. a deep folder cascade) is taller than the
+     fixed popup height, instead of scrolling only the timeline. */
+  overflow-x: hidden;
+  overflow-y: auto;
+
+  display: flex;
+  flex-direction: column;
+
   animation: body-fade-in 0.35s normal forwards ease-in-out;
+}
+
+/* Keep each section at its natural height so the body (not a section) is what scrolls. */
+body > * {
+  flex-shrink: 0;
 }
 
 @keyframes body-fade-in {

--- a/src/storage/Auth.js
+++ b/src/storage/Auth.js
@@ -31,6 +31,14 @@ export class Auth {
   #isChecked = false;
 
   /**
+   * Whether the stored API key was definitively rejected by the Perma.cc API (HTTP 401/403).
+   * When `true`, the key is kept on file (so it can be displayed / retried) but is not usable:
+   * the UI shows an "invalid key" panel rather than the sign-in or archive forms.
+   * @type {boolean}
+   */
+  #isInvalid = false;
+
+  /**
    * Date + time at which the API key was checked last.
    * @type {?Date}
    */
@@ -72,6 +80,7 @@ export class Auth {
     toSave[Auth.KEY] = {
       apiKey: this.#apiKey,
       isChecked: this.#isChecked,
+      isInvalid: this.#isInvalid,
       lastCheck: this.#lastCheck === null ? null : String(this.#lastCheck),
     };
 
@@ -109,6 +118,17 @@ export class Auth {
 
   get isChecked() {
     return this.#isChecked;
+  }
+
+  /**
+   * @param {any} newValue - Will be cast into a boolean
+   */
+  set isInvalid(newValue) {
+    this.#isInvalid = Boolean(newValue);
+  }
+
+  get isInvalid() {
+    return this.#isInvalid;
   }
 
   /**

--- a/src/storage/Folders.js
+++ b/src/storage/Folders.js
@@ -12,48 +12,49 @@ import { BROWSER } from "../constants/index.js"
 
 /**
  * This class directly interacts with `browser.storage.local` to push / pull and manage the "folders" key.
+ *
+ * Folders are navigated as a lazy cascade rather than loaded all at once: only the folders along
+ * the path the user has opened are fetched (top-level on open, a folder's children when it is
+ * selected). This keeps loading O(depth) instead of O(tree size) — registrar users can have very
+ * large trees. See `background/foldersPullList` and `background/foldersPick`.
  */
 export class Folders {
   /**
-   * Key given to this object in `browser.storage.local`. 
+   * Key given to this object in `browser.storage.local`.
    */
   static KEY = "folders";
 
   /**
-   * Id of the folder the user picked as its default.
+   * Id of the folder the user picked as the capture target (the deepest folder selected in the
+   * cascade). Read by `archiveCreate` as `parentFolderId`.
    * @type {?number}
    */
   #pick = null;
 
   /**
-   * List of all the folders the user can write into, sorted hierarchically.
-   * 
-   * Format: 
-   * [
-   *   { id: 158296, depth: 0, name: 'Personal Links' },
-   *   { id: 161019, depth: 1, name: 'Foo' },
-   *   { id: 161022, depth: 1, name: 'Lorem' },
-   *   { id: 161020, depth: 2, name: 'Bar' },
-   *   { id: 161021, depth: 2, name: 'Baz' },
-   *   { id: 161023, depth: 2, name: 'Ipsum' },
-   *   { id: 161026, depth: 3, name: 'Amet' },
-   *   { id: 161024, depth: 3, name: 'Dolor' },
-   *   { id: 161025, depth: 3, name: 'Sit' },
-   *   { id: 161029, depth: 4, name: 'Consequentur' }
-   * ]
-   * @type {Object[]}
+   * Selected folder id at each cascade level. `path[i]` is the folder chosen in the i-th select.
+   * The last entry is the current target (`pick`). Empty until a folder is chosen.
+   * @type {number[]}
    */
-  #available = [];
+  #path = [];
+
+  /**
+   * Option lists for each cascade level. `levels[0]` is the top-level folders; `levels[i]` (i > 0)
+   * is the children of `path[i - 1]`. Each entry is `{ id, name, hasChildren }` (read-only folders,
+   * which can't be capture targets, are filtered out upstream).
+   * @type {Array<Array<{id: number, name: string, hasChildren: boolean}>>}
+   */
+  #levels = [];
 
   /**
    * Creates and returns an instance of `Folders` using data from storage.
    * Use this static method to load "folders" from storage.
-   * 
+   *
    * Usage:
    * ```javascript
-   * const status = await Folders.fromStorage();
+   * const folders = await Folders.fromStorage();
    * ```
-   * 
+   *
    * @return {Promise<Folders>}
    * @static
    * @async
@@ -73,36 +74,15 @@ export class Folders {
 
   /**
    * Saves the current object in store.
-   * Checks and validates `this.#available` before saving to make sure it is an array of objects containing `id` and `name`.
-   * 
    * @returns {Promise<boolean>}
-   * @async 
+   * @async
    */
   async save() {
-    // Checks and filters `this.#available`
-    const availableFiltered = [];
-
-    for (let entry of this.#available) {
-      if (!("id" in entry) || !("name" in entry) || !("depth" in entry)) {
-        throw new Error(
-          "`available` must be an array of objects containing at least `id` and `name`."
-        );
-      }
-
-      availableFiltered.push({
-        id: parseInt(entry.id),
-        depth: parseInt(entry.depth),
-        name: entry.name,
-      });
-    }
-
-    this.#available = availableFiltered;
-
-    // Save
     const toSave = {};
     toSave[Folders.KEY] = {
       pick: this.#pick,
-      available: this.#available
+      path: this.#path,
+      levels: this.#levels
     };
 
     await BROWSER.storage.local.set(toSave);
@@ -112,7 +92,7 @@ export class Folders {
   /**
    * Replaces the current object in store with an "empty" one.
    * @returns {Promise<boolean>}
-   * @async 
+   * @async
    */
   async reset() {
     await new Folders().save();
@@ -131,18 +111,33 @@ export class Folders {
   }
 
   /**
-   * @param {Array} newValue
+   * @param {number[]} newValue - Selected folder id per cascade level.
    */
-  set available(newValue) {
+  set path(newValue) {
     if (!(newValue instanceof Array)) {
-      throw new Error("`available` must be an array.");
+      throw new Error("`path` must be an array.");
     }
 
-    this.#available = newValue;
+    this.#path = newValue.map((id) => parseInt(id));
   }
 
-  get available() {
-    return this.#available;
+  get path() {
+    return this.#path;
+  }
+
+  /**
+   * @param {Array} newValue - Option lists, one per cascade level.
+   */
+  set levels(newValue) {
+    if (!(newValue instanceof Array)) {
+      throw new Error("`levels` must be an array.");
+    }
+
+    this.#levels = newValue;
+  }
+
+  get levels() {
+    return this.#levels;
   }
 
 }

--- a/src/storage/Status.js
+++ b/src/storage/Status.js
@@ -65,10 +65,52 @@ import { BROWSER } from "../constants/index.js"
   }
 
   /**
+   * Lock used by `update()` to serialize read-modify-write cycles. Each queued mutation runs only
+   * after the previous one has finished saving.
+   * @type {Promise<any>}
+   */
+  static #updateChain = Promise.resolve();
+
+  /**
+   * Atomically reads "status" from storage, applies `mutator`, and saves it back — serialized
+   * against every other `update()` call.
+   *
+   * The whole status blob is written as one object, so two handlers that each did
+   * `fromStorage()` → mutate → `save()` concurrently would clobber each other's fields with a
+   * stale snapshot (last write wins on the *entire* object). Several writers run on overlapping
+   * timers — the 2s capture-status poll, the 2.5s `statusCleanUp`, and archive create/delete/
+   * toggle — so this matters. Routing every mutation through this single chain guarantees each one
+   * sees the freshest stored value and no write is lost.
+   *
+   * The mutator receives the freshly-loaded `Status` and may be async. Return `false` from it to
+   * skip the save (e.g. nothing actually changed, to avoid a needless `storage.onChanged` event);
+   * any other return value (including `undefined`) saves.
+   *
+   * @param {(status: Status) => (boolean | void | Promise<boolean | void>)} mutator
+   * @returns {Promise<Status>} The (possibly mutated) status.
+   */
+  static update(mutator) {
+    const run = Status.#updateChain.then(async () => {
+      const status = await Status.fromStorage();
+      const result = await mutator(status);
+
+      if (result !== false) {
+        await status.save();
+      }
+
+      return status;
+    });
+
+    // Advance the chain even if this mutator throws, so one failure can't wedge the queue.
+    Status.#updateChain = run.catch(() => {});
+    return run;
+  }
+
+  /**
    * Saves the current object in store.
-   * 
+   *
    * @returns {Promise<boolean>}
-   * @async 
+   * @async
    */
   async save() {
     const toSave = {};

--- a/src/storage/Status.js
+++ b/src/storage/Status.js
@@ -39,6 +39,20 @@ import { BROWSER } from "../constants/index.js"
   #message = "";
 
   /**
+   * GUID of the archive whose capture is currently in progress, if any.
+   * Empty string when no capture is being tracked. Used to drive capture-status polling.
+   * @type {string}
+   */
+  #captureGuid = "";
+
+  /**
+   * Number of capture steps completed for the archive being captured (`PermaCaptureJob.step_count`).
+   * Used to render a progress bar. Perma capture jobs report ~5 steps.
+   * @type {number}
+   */
+  #captureStep = 0;
+
+  /**
    * Creates and returns an instance of `Status` using data from storage.
    * Use this static method to load "status" from storage.
    * 
@@ -117,7 +131,9 @@ import { BROWSER } from "../constants/index.js"
     toSave[Status.KEY] = {
       isLoading: this.#isLoading,
       lastLoadingInit: String(this.#lastLoadingInit),
-      message: this.#message
+      message: this.#message,
+      captureGuid: this.#captureGuid,
+      captureStep: this.#captureStep
     };
 
     await BROWSER.storage.local.set(toSave);
@@ -169,6 +185,29 @@ import { BROWSER } from "../constants/index.js"
 
   get message() {
     return this.#message;
+  }
+
+  /**
+   * @param {any} newValue - Will be cast into a string.
+   */
+  set captureGuid(newValue) {
+    this.#captureGuid = newValue ? String(newValue) : "";
+  }
+
+  get captureGuid() {
+    return this.#captureGuid;
+  }
+
+  /**
+   * @param {any} newValue - Will be cast into a number (0 if not parseable).
+   */
+  set captureStep(newValue) {
+    const parsed = parseInt(newValue);
+    this.#captureStep = Number.isNaN(parsed) ? 0 : parsed;
+  }
+
+  get captureStep() {
+    return this.#captureStep;
   }
 
 }

--- a/tests/components/ArchiveForm.spec.js
+++ b/tests/components/ArchiveForm.spec.js
@@ -7,7 +7,7 @@
  */
 import { expect } from "@playwright/test";
 import { test, WAIT_MS_AFTER_BOOT } from "../index.js";
-import { MOCK_API_KEY, MOCK_FOLDERS_LIST, MOCK_FOLDERS_PICK, MOCK_TAB_URL } from "../mocks.js";
+import { MOCK_API_KEY, MOCK_FOLDERS_CASCADE, MOCK_TAB_URL } from "../mocks.js";
 import { MESSAGE_IDS } from "../../src/constants/index.js";
 
 // Refresh extension page and wait `WAIT_MS_AFTER_BOOT` ms before each test.
@@ -16,16 +16,16 @@ test.beforeEach(async ({ page, extensionId }, testInfo) => {
   await page.goto(`chrome-extension://${extensionId}/popup/index.html`);
   await page.waitForTimeout(WAIT_MS_AFTER_BOOT);
 });
- 
+
 test("Enforces the singleton pattern.", async ({ page, extensionId }) => {
-  // Try to inject a second `<archive-form>` in the document. 
+  // Try to inject a second `<archive-form>` in the document.
   const count = await page.evaluate(() => {
     const extra = document.createElement("archive-form");
     document.querySelector("body").appendChild(extra);
- 
+
     return document.querySelectorAll("archive-form").length;
   });
- 
+
   expect(count).toBe(1); // Only the first one should remain.
 });
 
@@ -46,7 +46,7 @@ test('Sign-in form shows up (only) when `is-authenticated` is "false".',  async 
       document.querySelector("archive-form").setAttribute("is-authenticated", scenario.isAuthenticated);
 
       await new Promise(resolve => requestAnimationFrame(resolve));
-      
+
       return document.querySelectorAll("archive-form form[action='#sign-in']").length;
     }, scenario);
 
@@ -93,34 +93,37 @@ test("Sign-in form has a working link to Perma.cc's bookmarklet feature.",  asyn
 
 test('Archive creation form sends `ARCHIVE_CREATE_PUBLIC` runtime message on submit.',  async ({ page, extensionId }) => {
   // Monkey-patch `chrome.runtime.sendMessage` to intercept message.
-  const payload = await page.evaluate(async (dummyApiKey) => {
+  const payload = await page.evaluate(async ({ cascade }) => {
     let payload = null;
     chrome.runtime.sendMessage = data => payload = data;
 
-    document.querySelector("archive-form").setAttribute("is-authenticated", "true");
+    const archiveForm = document.querySelector("archive-form");
+    archiveForm.setAttribute("is-authenticated", "true");
+    // A folder target is required for the "Create" button to be enabled (it sets `parentFolderId`).
+    archiveForm.setAttribute("folders-cascade", JSON.stringify(cascade));
     await new Promise(resolve => requestAnimationFrame(resolve));
 
-    const signInForm = document.querySelector("archive-form form[action='#create-archive']");
-    signInForm.querySelector("button").click();
+    const createForm = archiveForm.querySelector("form[action='#create-archive']");
+    createForm.querySelector("button").click();
 
     return payload;
-  });
+  }, { cascade: MOCK_FOLDERS_CASCADE });
 
   expect(payload.messageId).toBe(MESSAGE_IDS.ARCHIVE_CREATE_PUBLIC);
 });
 
-test('Archive creation renders `folders-list`.',  async ({ page, extensionId }) => {
-  const optionsHaveRendered = await page.evaluate(async (MOCK_FOLDERS_LIST) => {
+test('Archive creation renders the folder cascade (`folders-cascade`).',  async ({ page, extensionId }) => {
+  const optionsHaveRendered = await page.evaluate(async ({ cascade }) => {
     const archiveForm = document.querySelector("archive-form");
 
     archiveForm.setAttribute("is-authenticated", "true");
-    archiveForm.setAttribute("folders-list", JSON.stringify(MOCK_FOLDERS_LIST));
+    archiveForm.setAttribute("folders-cascade", JSON.stringify(cascade));
 
     await new Promise(resolve => requestAnimationFrame(resolve));
 
     let optionsHaveRendered = true;
 
-    for (let option of Object.values(MOCK_FOLDERS_LIST)) {
+    for (let option of cascade.levels[0]) {
       if (!archiveForm.querySelector(`option[value="${option.id}"]`)) {
         optionsHaveRendered = false;
         break;
@@ -128,80 +131,62 @@ test('Archive creation renders `folders-list`.',  async ({ page, extensionId }) 
     }
 
     return optionsHaveRendered;
-  }, MOCK_FOLDERS_LIST);
+  }, { cascade: MOCK_FOLDERS_CASCADE });
 
   expect(optionsHaveRendered).toBe(true);
 });
 
-test('Archive creation takes into account `folder-pick`.',  async ({ page, extensionId }) => {
-  const options = {
-    foldersList: MOCK_FOLDERS_LIST, 
-    foldersPick: MOCK_FOLDERS_PICK
-  };
-
-  const optionsIsSelected = await page.evaluate(async (options) => {
+test('Archive creation marks the picked folder (`cascade.pick`) as selected.',  async ({ page, extensionId }) => {
+  const optionIsSelected = await page.evaluate(async ({ cascade }) => {
     const archiveForm = document.querySelector("archive-form");
 
     archiveForm.setAttribute("is-authenticated", "true");
-    archiveForm.setAttribute("folders-list", JSON.stringify(options.foldersList));
-    archiveForm.setAttribute("folders-pick", options.foldersPick);
+    archiveForm.setAttribute("folders-cascade", JSON.stringify(cascade));
 
     await new Promise((resolve) => requestAnimationFrame(resolve));
 
-    if (archiveForm.querySelector(`option[value="${options.foldersPick}"][selected]`)) {
-      return true;
-    }
-    else {
-      return false;
-    }
+    return Boolean(archiveForm.querySelector(`option[value="${cascade.pick}"][selected]`));
+  }, { cascade: MOCK_FOLDERS_CASCADE });
 
-  }, options);
-
-  expect(optionsIsSelected).toBe(true);
+  expect(optionIsSelected).toBe(true);
 });
 
 test('Archive creation form sends `FOLDERS_PICK_ONE` runtime message on folder `<select>` change.',  async ({ page, extensionId }) => {
-  const options = {
-    foldersList: MOCK_FOLDERS_LIST, 
-    foldersPick: MOCK_FOLDERS_PICK
-  };
-
   // Monkey-patch `chrome.runtime.sendMessage` to intercept message.
-  const payload = await page.evaluate(async (options) => {
+  const payload = await page.evaluate(async ({ cascade }) => {
     let payload = null;
     chrome.runtime.sendMessage = data => payload = data;
-    
+
     const archiveForm = document.querySelector("archive-form");
 
     archiveForm.setAttribute("is-authenticated", "true");
-    archiveForm.setAttribute("folders-list", JSON.stringify(options.foldersList));
+    archiveForm.setAttribute("folders-cascade", JSON.stringify(cascade));
 
     await new Promise((resolve) => requestAnimationFrame(resolve));
 
-    archiveForm.querySelector("select").value = options.foldersPick;
-    archiveForm.querySelector("select").dispatchEvent(new Event("change"));
+    // Change the top-level (level 0) cascade select to a different folder.
+    const select = archiveForm.querySelector("select[data-level='0']");
+    select.value = "2";
+    select.dispatchEvent(new Event("change"));
 
     return payload;
 
-  }, options);
+  }, { cascade: MOCK_FOLDERS_CASCADE });
 
   expect(payload.messageId).toBe(MESSAGE_IDS.FOLDERS_PICK_ONE);
-  expect(payload.folderId).toBe(`${MOCK_FOLDERS_PICK}`);
+  expect(payload.level).toBe(0);
+  expect(payload.folderId).toBe("2");
 });
 
 test('Inputs are disabled when `is-loading` is "true"',  async ({ page, extensionId }) => {
   const scenarios = [
     {
-      isAuthenticated: false,
-      isLoading: true,
-      foldersList: "",
-      foldersPick: "",
+      isAuthenticated: "false", // Sign-in form
+      cascade: null,
     },
     {
-      isAuthenticated: false,
-      isLoading: true,
-      foldersList: MOCK_FOLDERS_LIST,
-      foldersPick: MOCK_FOLDERS_PICK,
+      isAuthenticated: "true", // Archive creation form, with a rendered folder cascade
+      cascade: MOCK_FOLDERS_CASCADE,
     }
   ];
 
@@ -210,14 +195,10 @@ test('Inputs are disabled when `is-loading` is "true"',  async ({ page, extensio
       const archiveForm = document.querySelector("archive-form");
 
       archiveForm.setAttribute("is-authenticated", scenario.isAuthenticated);
-      archiveForm.setAttribute("is-loading", scenario.isLoading);
+      archiveForm.setAttribute("is-loading", "true");
 
-      if (scenario.foldersList) {
-        archiveForm.setAttribute("folders-list", JSON.stringify(scenario.foldersList));
-      }
-
-      if (scenario.foldersPick) {
-        archiveForm.setAttribute("folders-pick", scenario.foldersPick);
+      if (scenario.cascade) {
+        archiveForm.setAttribute("folders-cascade", JSON.stringify(scenario.cascade));
       }
 
       await new Promise((resolve) => requestAnimationFrame(resolve));

--- a/tests/components/ArchiveForm.spec.js
+++ b/tests/components/ArchiveForm.spec.js
@@ -143,14 +143,42 @@ test("Sign-in form has a working link to Perma.cc's bookmarklet feature.",  asyn
   expect(href).toContain(tabUrl);
 });
 
+test('Non-capturable tabs show the "can\'t be archived" panel instead of the create form.', async ({ page, extensionId }) => {
+  // A representative non-capturable url per category Perma refuses (see `isCapturableUrl`).
+  const nonCapturableUrls = [
+    "about:blank",                 // browser-internal page
+    "chrome://extensions",         // non-http scheme
+    "https://perma.cc/ABCD-1234",  // perma link (not re-capturable)
+    "http://localhost:3000/",      // address Perma's servers can't reach
+  ];
+
+  for (let tabUrl of nonCapturableUrls) {
+    const result = await page.evaluate(async (tabUrl) => {
+      const archiveForm = document.querySelector("archive-form");
+      archiveForm.setAttribute("auth-state", "valid");
+      archiveForm.setAttribute("tab-url", tabUrl);
+      await new Promise(resolve => requestAnimationFrame(resolve));
+
+      return {
+        panelCount: archiveForm.querySelectorAll(".not-capturable").length,
+        createFormCount: archiveForm.querySelectorAll("form[action='#create-archive']").length,
+      };
+    }, tabUrl);
+
+    expect(result.panelCount, tabUrl).toBe(1);
+    expect(result.createFormCount, tabUrl).toBe(0);
+  }
+});
+
 test('Archive creation form sends `ARCHIVE_CREATE_PUBLIC` runtime message on submit.',  async ({ page, extensionId }) => {
   // Monkey-patch `chrome.runtime.sendMessage` to intercept message.
-  const payload = await page.evaluate(async ({ cascade }) => {
+  const payload = await page.evaluate(async ({ cascade, tabUrl }) => {
     let payload = null;
     chrome.runtime.sendMessage = data => payload = data;
 
     const archiveForm = document.querySelector("archive-form");
     archiveForm.setAttribute("auth-state", "valid");
+    archiveForm.setAttribute("tab-url", tabUrl); // Capturable url -> the create form renders.
     // A folder target is required for the "Create" button to be enabled (it sets `parentFolderId`).
     archiveForm.setAttribute("folders-cascade", JSON.stringify(cascade));
     await new Promise(resolve => requestAnimationFrame(resolve));
@@ -159,16 +187,17 @@ test('Archive creation form sends `ARCHIVE_CREATE_PUBLIC` runtime message on sub
     createForm.querySelector("button").click();
 
     return payload;
-  }, { cascade: MOCK_FOLDERS_CASCADE });
+  }, { cascade: MOCK_FOLDERS_CASCADE, tabUrl: MOCK_TAB_URL });
 
   expect(payload.messageId).toBe(MESSAGE_IDS.ARCHIVE_CREATE_PUBLIC);
 });
 
 test('Archive creation renders the folder cascade (`folders-cascade`).',  async ({ page, extensionId }) => {
-  const optionsHaveRendered = await page.evaluate(async ({ cascade }) => {
+  const optionsHaveRendered = await page.evaluate(async ({ cascade, tabUrl }) => {
     const archiveForm = document.querySelector("archive-form");
 
     archiveForm.setAttribute("auth-state", "valid");
+    archiveForm.setAttribute("tab-url", tabUrl); // Capturable url -> the create form renders.
     archiveForm.setAttribute("folders-cascade", JSON.stringify(cascade));
 
     await new Promise(resolve => requestAnimationFrame(resolve));
@@ -183,35 +212,37 @@ test('Archive creation renders the folder cascade (`folders-cascade`).',  async 
     }
 
     return optionsHaveRendered;
-  }, { cascade: MOCK_FOLDERS_CASCADE });
+  }, { cascade: MOCK_FOLDERS_CASCADE, tabUrl: MOCK_TAB_URL });
 
   expect(optionsHaveRendered).toBe(true);
 });
 
 test('Archive creation marks the picked folder (`cascade.pick`) as selected.',  async ({ page, extensionId }) => {
-  const optionIsSelected = await page.evaluate(async ({ cascade }) => {
+  const optionIsSelected = await page.evaluate(async ({ cascade, tabUrl }) => {
     const archiveForm = document.querySelector("archive-form");
 
     archiveForm.setAttribute("auth-state", "valid");
+    archiveForm.setAttribute("tab-url", tabUrl); // Capturable url -> the create form renders.
     archiveForm.setAttribute("folders-cascade", JSON.stringify(cascade));
 
     await new Promise((resolve) => requestAnimationFrame(resolve));
 
     return Boolean(archiveForm.querySelector(`option[value="${cascade.pick}"][selected]`));
-  }, { cascade: MOCK_FOLDERS_CASCADE });
+  }, { cascade: MOCK_FOLDERS_CASCADE, tabUrl: MOCK_TAB_URL });
 
   expect(optionIsSelected).toBe(true);
 });
 
 test('Archive creation form sends `FOLDERS_PICK_ONE` runtime message on folder `<select>` change.',  async ({ page, extensionId }) => {
   // Monkey-patch `chrome.runtime.sendMessage` to intercept message.
-  const payload = await page.evaluate(async ({ cascade }) => {
+  const payload = await page.evaluate(async ({ cascade, tabUrl }) => {
     let payload = null;
     chrome.runtime.sendMessage = data => payload = data;
 
     const archiveForm = document.querySelector("archive-form");
 
     archiveForm.setAttribute("auth-state", "valid");
+    archiveForm.setAttribute("tab-url", tabUrl); // Capturable url -> the create form renders.
     archiveForm.setAttribute("folders-cascade", JSON.stringify(cascade));
 
     await new Promise((resolve) => requestAnimationFrame(resolve));
@@ -223,7 +254,7 @@ test('Archive creation form sends `FOLDERS_PICK_ONE` runtime message on folder `
 
     return payload;
 
-  }, { cascade: MOCK_FOLDERS_CASCADE });
+  }, { cascade: MOCK_FOLDERS_CASCADE, tabUrl: MOCK_TAB_URL });
 
   expect(payload.messageId).toBe(MESSAGE_IDS.FOLDERS_PICK_ONE);
   expect(payload.level).toBe(0);
@@ -239,6 +270,7 @@ test('Inputs are disabled when `is-loading` is "true"',  async ({ page, extensio
     {
       authState: "valid", // Archive creation form, with a rendered folder cascade
       cascade: MOCK_FOLDERS_CASCADE,
+      tabUrl: MOCK_TAB_URL, // Capturable url -> the create form (with its inputs) renders.
     }
   ];
 
@@ -248,6 +280,10 @@ test('Inputs are disabled when `is-loading` is "true"',  async ({ page, extensio
 
       archiveForm.setAttribute("auth-state", scenario.authState);
       archiveForm.setAttribute("is-loading", "true");
+
+      if (scenario.tabUrl) {
+        archiveForm.setAttribute("tab-url", scenario.tabUrl);
+      }
 
       if (scenario.cascade) {
         archiveForm.setAttribute("folders-cascade", JSON.stringify(scenario.cascade));

--- a/tests/components/ArchiveForm.spec.js
+++ b/tests/components/ArchiveForm.spec.js
@@ -29,21 +29,21 @@ test("Enforces the singleton pattern.", async ({ page, extensionId }) => {
   expect(count).toBe(1); // Only the first one should remain.
 });
 
-test('Sign-in form shows up (only) when `is-authenticated` is "false".',  async ({ page, extensionId }) => {
+test('Sign-in form shows up (only) when `auth-state` is "signedout".',  async ({ page, extensionId }) => {
   const scenarios = [
     {
-      isAuthenticated: "false",
+      authState: "signedout",
       signInFormCount: 1,
     },
     {
-      isAuthenticated: "true",
+      authState: "valid",
       signInFormCount: 0,
     },
   ];
 
   for (let scenario of Object.values(scenarios)) {
     const count = await page.evaluate(async (scenario) => {
-      document.querySelector("archive-form").setAttribute("is-authenticated", scenario.isAuthenticated);
+      document.querySelector("archive-form").setAttribute("auth-state", scenario.authState);
 
       await new Promise(resolve => requestAnimationFrame(resolve));
 
@@ -55,13 +55,65 @@ test('Sign-in form shows up (only) when `is-authenticated` is "false".',  async 
 
 });
 
+test('Invalid-key panel shows (only) when `auth-state` is "invalid", with retry + update-key buttons and the key hint.', async ({ page, extensionId }) => {
+  const result = await page.evaluate(async () => {
+    const archiveForm = document.querySelector("archive-form");
+    archiveForm.setAttribute("key-hint", "aB3z");
+    archiveForm.setAttribute("auth-state", "invalid");
+    await new Promise(resolve => requestAnimationFrame(resolve));
+
+    return {
+      panelCount: archiveForm.querySelectorAll(".invalid-key").length,
+      signInFormCount: archiveForm.querySelectorAll("form[action='#sign-in']").length,
+      retryCount: archiveForm.querySelectorAll('.invalid-key button[data-action="retry"]').length,
+      updateCount: archiveForm.querySelectorAll('.invalid-key button[data-action="update-key"]').length,
+      text: archiveForm.querySelector(".invalid-key p")?.innerText ?? "",
+    };
+  });
+
+  expect(result.panelCount).toBe(1);
+  expect(result.signInFormCount).toBe(0);
+  expect(result.retryCount).toBe(1);
+  expect(result.updateCount).toBe(1);
+  expect(result.text).toContain("aB3z"); // Key hint surfaced so the user knows which key failed.
+});
+
+test('Invalid-key panel "Retry" sends `AUTH_CHECK`; "Update key" reveals the sign-in form.', async ({ page, extensionId }) => {
+  const result = await page.evaluate(async (AUTH_CHECK) => {
+    let payload = null;
+    chrome.runtime.sendMessage = data => payload = data;
+
+    const archiveForm = document.querySelector("archive-form");
+    archiveForm.setAttribute("auth-state", "invalid");
+    await new Promise(resolve => requestAnimationFrame(resolve));
+
+    // Retry re-checks the stored key.
+    archiveForm.querySelector('button[data-action="retry"]').click();
+    const retryMessageId = payload?.messageId;
+
+    // Update key swaps the panel for the sign-in form (without changing `auth-state`).
+    archiveForm.querySelector('button[data-action="update-key"]').click();
+    await new Promise(resolve => requestAnimationFrame(resolve));
+
+    return {
+      retryMessageId,
+      signInFormCount: archiveForm.querySelectorAll("form[action='#sign-in']").length,
+      panelCount: archiveForm.querySelectorAll(".invalid-key").length,
+    };
+  }, MESSAGE_IDS.AUTH_CHECK);
+
+  expect(result.retryMessageId).toBe(MESSAGE_IDS.AUTH_CHECK);
+  expect(result.signInFormCount).toBe(1);
+  expect(result.panelCount).toBe(0);
+});
+
 test('Sign-in form sends `AUTH_SIGN_IN` runtime message on submit.',  async ({ page, extensionId }) => {
   // Monkey-patch `chrome.runtime.sendMessage` to intercept message.
   const payload = await page.evaluate(async (MOCK_API_KEY) => {
     let payload = null;
     chrome.runtime.sendMessage = data => payload = data;
 
-    document.querySelector("archive-form").setAttribute("is-authenticated", "false");
+    document.querySelector("archive-form").setAttribute("auth-state", "signedout");
     await new Promise(resolve => requestAnimationFrame(resolve));
 
     const signInForm = document.querySelector("archive-form form[action='#sign-in']");
@@ -81,7 +133,7 @@ test("Sign-in form has a working link to Perma.cc's bookmarklet feature.",  asyn
   const tabUrl = MOCK_TAB_URL;
 
   await page.evaluate(async (tabUrl) => {
-    document.querySelector("archive-form").setAttribute("is-authenticated", "false");
+    document.querySelector("archive-form").setAttribute("auth-state", "signedout");
     document.querySelector("archive-form").setAttribute("tab-url", tabUrl);
     await new Promise(resolve => requestAnimationFrame(resolve));
   }, tabUrl);
@@ -98,7 +150,7 @@ test('Archive creation form sends `ARCHIVE_CREATE_PUBLIC` runtime message on sub
     chrome.runtime.sendMessage = data => payload = data;
 
     const archiveForm = document.querySelector("archive-form");
-    archiveForm.setAttribute("is-authenticated", "true");
+    archiveForm.setAttribute("auth-state", "valid");
     // A folder target is required for the "Create" button to be enabled (it sets `parentFolderId`).
     archiveForm.setAttribute("folders-cascade", JSON.stringify(cascade));
     await new Promise(resolve => requestAnimationFrame(resolve));
@@ -116,7 +168,7 @@ test('Archive creation renders the folder cascade (`folders-cascade`).',  async 
   const optionsHaveRendered = await page.evaluate(async ({ cascade }) => {
     const archiveForm = document.querySelector("archive-form");
 
-    archiveForm.setAttribute("is-authenticated", "true");
+    archiveForm.setAttribute("auth-state", "valid");
     archiveForm.setAttribute("folders-cascade", JSON.stringify(cascade));
 
     await new Promise(resolve => requestAnimationFrame(resolve));
@@ -140,7 +192,7 @@ test('Archive creation marks the picked folder (`cascade.pick`) as selected.',  
   const optionIsSelected = await page.evaluate(async ({ cascade }) => {
     const archiveForm = document.querySelector("archive-form");
 
-    archiveForm.setAttribute("is-authenticated", "true");
+    archiveForm.setAttribute("auth-state", "valid");
     archiveForm.setAttribute("folders-cascade", JSON.stringify(cascade));
 
     await new Promise((resolve) => requestAnimationFrame(resolve));
@@ -159,7 +211,7 @@ test('Archive creation form sends `FOLDERS_PICK_ONE` runtime message on folder `
 
     const archiveForm = document.querySelector("archive-form");
 
-    archiveForm.setAttribute("is-authenticated", "true");
+    archiveForm.setAttribute("auth-state", "valid");
     archiveForm.setAttribute("folders-cascade", JSON.stringify(cascade));
 
     await new Promise((resolve) => requestAnimationFrame(resolve));
@@ -181,11 +233,11 @@ test('Archive creation form sends `FOLDERS_PICK_ONE` runtime message on folder `
 test('Inputs are disabled when `is-loading` is "true"',  async ({ page, extensionId }) => {
   const scenarios = [
     {
-      isAuthenticated: "false", // Sign-in form
+      authState: "signedout", // Sign-in form
       cascade: null,
     },
     {
-      isAuthenticated: "true", // Archive creation form, with a rendered folder cascade
+      authState: "valid", // Archive creation form, with a rendered folder cascade
       cascade: MOCK_FOLDERS_CASCADE,
     }
   ];
@@ -194,7 +246,7 @@ test('Inputs are disabled when `is-loading` is "true"',  async ({ page, extensio
     const inputsAreDisabled = await page.evaluate(async (scenario) => {
       const archiveForm = document.querySelector("archive-form");
 
-      archiveForm.setAttribute("is-authenticated", scenario.isAuthenticated);
+      archiveForm.setAttribute("auth-state", scenario.authState);
       archiveForm.setAttribute("is-loading", "true");
 
       if (scenario.cascade) {

--- a/tests/components/ArchiveTimeline.spec.js
+++ b/tests/components/ArchiveTimeline.spec.js
@@ -12,22 +12,22 @@ import { MOCK_ARCHIVE_TIMELINE, MOCK_ARCHIVE_GUID } from "../mocks.js";
 
 // Refresh extension page and wait `WAIT_MS_AFTER_BOOT` ms before each test.
 // This page contains an instance of `<archive-timeline>`.
-// We pass `is-authenticated="true"` to `<archive-timeline>` by default (most common test setup).
+// We pass `auth-state="valid"` to `<archive-timeline>` by default (most common test setup).
 test.beforeEach(async ({ page, extensionId }, testInfo) => {
   await page.goto(`chrome-extension://${extensionId}/popup/index.html`);
   await page.waitForTimeout(WAIT_MS_AFTER_BOOT);
 
   await page.evaluate(async () => {
-    document.querySelector("archive-form").setAttribute("is-authenticated", "true");
-    document.querySelector("archive-timeline").setAttribute("is-authenticated", "true");
-    document.querySelector("status-bar").setAttribute("is-authenticated", "true");
+    document.querySelector("archive-form").setAttribute("auth-state", "valid");
+    document.querySelector("archive-timeline").setAttribute("auth-state", "valid");
+    document.querySelector("status-bar").setAttribute("auth-state", "valid");
     await new Promise(resolve => requestAnimationFrame(resolve));
   });
 });
 
-test('Does not render if `is-authenticated` is not "true".', async ({ page, extensionId }) => {
+test('Does not render if `auth-state` is "signedout".', async ({ page, extensionId }) => {
   await page.evaluate(async () => {
-    document.querySelector("archive-timeline").setAttribute("is-authenticated", "false");
+    document.querySelector("archive-timeline").setAttribute("auth-state", "signedout");
     await new Promise(resolve => requestAnimationFrame(resolve));
   });
 

--- a/tests/components/ArchiveTimelineItem.spec.js
+++ b/tests/components/ArchiveTimelineItem.spec.js
@@ -11,17 +11,17 @@ import { MOCK_ARCHIVE_TIMELINE, MOCK_ARCHIVE_GUID } from "../mocks.js";
 
 // Refresh extension page and wait `WAIT_MS_AFTER_BOOT` ms before each test.
 // This page contains an instance of `<archive-timeline>`
-// - Set `is-authenticated` to "true" on `<archive-form>` and `<archive-timeline>` so we can use `<archive-timeline>`.
+// - Set `auth-state` to "valid" on `<archive-form>` and `<archive-timeline>` so we can use `<archive-timeline>`.
 // - Mock a timeline in `<archive-timeline>`
 test.beforeEach(async ({ page, extensionId }, testInfo) => {
   await page.goto(`chrome-extension://${extensionId}/popup/index.html`);
   await page.waitForTimeout(WAIT_MS_AFTER_BOOT);
 
   await page.evaluate(async (MOCK_ARCHIVE_TIMELINE) => {
-    document.querySelector("archive-form").setAttribute("is-authenticated", "true");
+    document.querySelector("archive-form").setAttribute("auth-state", "valid");
     
     const archiveTimeline = document.querySelector("archive-timeline");
-    archiveTimeline.setAttribute("is-authenticated", "true");
+    archiveTimeline.setAttribute("auth-state", "valid");
     archiveTimeline.addArchives(MOCK_ARCHIVE_TIMELINE)
 
     await new Promise(resolve => requestAnimationFrame(resolve));

--- a/tests/components/ArchiveTimelineItem.spec.js
+++ b/tests/components/ArchiveTimelineItem.spec.js
@@ -82,10 +82,11 @@ test("`capture-status` is observed and taken into account.", async ({ page, exte
       await new Promise(resolve => requestAnimationFrame(resolve));
     }, status);
 
-    // Based on `capture-status`, a > span should contain:
+    // Based on `capture-status`, the caption span should contain:
     // - If status is "failed" or "pending": a message
     // - If status is anything else: a date
-    const spanContent = await page.locator("archive-timeline-item:first-of-type a > span").innerText();
+    // (A pending capture also renders a sibling `span.capture-progress` progress bar, so exclude it.)
+    const spanContent = await page.locator("archive-timeline-item:first-of-type a > span:not(.capture-progress)").innerText();
 
     expect(new Date(spanContent)).toBeInstanceOf(Date);
 

--- a/tests/components/StatusBar.spec.js
+++ b/tests/components/StatusBar.spec.js
@@ -30,15 +30,25 @@ test("Enforces the singleton pattern", async ({ page, extensionId }) => {
   expect(count).toBe(1); // Only the first one should remain.
 });
 
-test('Sign-out button shows when `is-authenticated` is "true" and `is-loading` is "false".', async ({ page, extensionId }) => {
+test('Sign-out button shows when a key is on file (`auth-state` "valid"/"invalid") and `is-loading` is "false".', async ({ page, extensionId }) => {
   const scenarios = [
     {
-      isAuthenticated: true,
+      authState: "valid",
       isLoading: false,
       buttonCount: 1,
     },
     {
-      isAuthenticated: true,
+      authState: "invalid",
+      isLoading: false,
+      buttonCount: 1,
+    },
+    {
+      authState: "signedout",
+      isLoading: false,
+      buttonCount: 0,
+    },
+    {
+      authState: "valid",
       isLoading: true,
       buttonCount: 0,
     },
@@ -48,13 +58,13 @@ test('Sign-out button shows when `is-authenticated` is "true" and `is-loading` i
     await page.evaluate(async(scenario) => {
       const statusBar = document.querySelector("status-bar");
 
-      statusBar.setAttribute("is-authenticated", scenario.isAuthenticated);
+      statusBar.setAttribute("auth-state", scenario.authState);
       statusBar.setAttribute("is-loading", scenario.isLoading);
 
       await new Promise(resolve => requestAnimationFrame(resolve));
     }, scenario);
-  
-    expect(await page.getAttribute("status-bar", "is-authenticated")).toBe(`${scenario.isAuthenticated}`);
+
+    expect(await page.getAttribute("status-bar", "auth-state")).toBe(`${scenario.authState}`);
     expect(await page.getAttribute("status-bar", "is-loading")).toBe(`${scenario.isLoading}`);
   
     expect(
@@ -72,7 +82,7 @@ test("Sign-out button sends `AUTH_SIGN_OUT` runtime message on click.", async ({
     let payload = null;
     chrome.runtime.sendMessage = data => payload = data;
 
-    document.querySelector("status-bar").setAttribute("is-authenticated", "true");
+    document.querySelector("status-bar").setAttribute("auth-state", "valid");
     document.querySelector("status-bar").setAttribute("is-loading", "false");
 
     document.querySelector("status-bar > button").click();

--- a/tests/index.js
+++ b/tests/index.js
@@ -6,6 +6,11 @@
  * @description Entry point for browser-based test suite. Defines suite-wide tools and fixtures.
  */
 import { test as base, chromium } from "@playwright/test";
+import { PermaAPI } from "@harvard-lil/perma-js-sdk";
+import { PERMA_API_BASE_URL } from "../src/constants/index.js";
+
+export const PLACEHOLDER_TESTS_API_KEY = "abcedfghijklmnopqrstuvwxyz12345678901234";
+export const EXPECTED_TESTS_API_USER = "perma-js-sdk-test-user";
 
 /**
  * Time (in MS) to wait before running a test.
@@ -24,12 +29,38 @@ export const EXTENSION_PATH = "./dist/";
  * - Finds the extension id and feeds it to every test.
  */
 export const test = base.extend({
+  liveApiAccountGuard: [async ({ }, use) => {
+    const apiKey = process.env.TESTS_API_KEY;
+    const isLiveApiKey = Boolean(apiKey && apiKey !== PLACEHOLDER_TESTS_API_KEY);
+    const allowOtherUser = process.env.TESTS_API_ALLOW_NON_TEST_USER === "1";
+
+    if (isLiveApiKey && !allowOtherUser) {
+      const api = new PermaAPI(apiKey, PERMA_API_BASE_URL);
+      const user = await api.pullUser();
+
+      if (user.full_name !== EXPECTED_TESTS_API_USER) {
+        throw new Error(
+          `TESTS_API_KEY belongs to "${user.full_name}", expected "${EXPECTED_TESTS_API_USER}". ` +
+          "Set TESTS_API_ALLOW_NON_TEST_USER=1 to intentionally run the live API tests with another account."
+        );
+      }
+    }
+
+    await use();
+  }, { scope: "worker", auto: true }],
+
   context: async ({ }, use) => {
     const pathToExtension = EXTENSION_PATH;
+
+    // Extensions can't load in Chromium's legacy headless mode, only in the new one (--headless=new).
+    // So we keep Playwright's `headless: false` and opt into new headless ourselves via an arg, gated
+    // on HEADLESS (default on; set HEADLESS=false — e.g. `just headful=1 test` — to watch the browser).
+    const headless = process.env.HEADLESS !== "false";
 
     const context = await chromium.launchPersistentContext("", {
       headless: false,
       args: [
+        ...(headless ? ["--headless=new"] : []),
         `--disable-extensions-except=${pathToExtension}`,
         `--load-extension=${pathToExtension}`,
       ],

--- a/tests/mocks.js
+++ b/tests/mocks.js
@@ -7,20 +7,21 @@
  */
 
 /**
- * Valid mock for a folders list.
+ * Valid mock for the folder cascade, as consumed by `<archive-form>`'s `folders-cascade` attribute
+ * (see `storage/Folders`). A single opened level (top-level folders) with "Blog Posts" picked.
  * @constant
  */
-export const MOCK_FOLDERS_LIST = [
-  { "id": 1, "depth": 0, "name": "Personal Links" },
-  { "id": 3, "depth": 0, "name": "Blog Posts" },
-  { "id": 2, "depth": 0, "name": "Other links" },
-];
-
-/**
- * Valid mock for folder pick.
- * @constant
- */
-export const MOCK_FOLDERS_PICK = 3;
+export const MOCK_FOLDERS_CASCADE = {
+  levels: [
+    [
+      { id: 1, name: "Personal Links", hasChildren: false },
+      { id: 3, name: "Blog Posts", hasChildren: false },
+      { id: 2, name: "Other links", hasChildren: false },
+    ],
+  ],
+  path: [3],
+  pick: 3,
+};
 
 /**
  * Valid mock for archive timeline.

--- a/tests/scenarios/createArchive.spec.js
+++ b/tests/scenarios/createArchive.spec.js
@@ -33,7 +33,11 @@ test.beforeEach(async ({ page, extensionId }, testInfo) => {
 test("App can request the creation of an archive and list the newly created entry.", async ({ page, extensionId }) => {
   const scenarios = [
     {
-      url: MOCK_TAB_URL,
+      // Use a unique URL per run so the timeline starts empty. The test account accumulates archives
+      // for any fixed URL across runs, and the timeline only pulls the first 100 for a given URL
+      // (see `archivePullTimeline`) — so on a reused URL the freshly created entry can fall outside
+      // that page and the count never increments. A unique URL sidesteps that and keeps the diff at 1.
+      url: `${MOCK_TAB_URL}?perma-extension-e2e=${Date.now()}`,
       title: MOCK_TAB_TITLE,
       expectedArchivesCountDiff: 1
     },
@@ -61,7 +65,9 @@ test("App can request the creation of an archive and list the newly created entr
       let archivesCountBefore = document.querySelectorAll("archive-timeline-item").length;
       let archivesCountAfter = 0;
   
-      document.querySelector("archive-form form[action='#create-archive'] button").click();
+      // Non-capturable pages (e.g. `chrome://extensions`) render the "can't be archived" panel
+      // instead of the create form, so there's no button to click — and no archive is created.
+      document.querySelector("archive-form form[action='#create-archive'] button")?.click();
       await new Promise(resolve => setTimeout(resolve, 5000));
   
       archivesCountAfter = document.querySelectorAll("archive-timeline-item").length;

--- a/tests/scenarios/pickFolder.spec.js
+++ b/tests/scenarios/pickFolder.spec.js
@@ -6,7 +6,38 @@
  * @description E2E Testing scenario: Picking a new default folder. Assumes "env.TESTS_API_KEY" is available and valid.
  */
 import { expect } from "@playwright/test";
-import { test, WAIT_MS_AFTER_BOOT } from "../index.js";
+import { PermaAPI } from "@harvard-lil/perma-js-sdk";
+import { test, WAIT_MS_AFTER_BOOT, EXPECTED_TESTS_API_USER } from "../index.js";
+import { MOCK_TAB_URL, MOCK_TAB_TITLE } from "../mocks.js";
+import { MESSAGE_IDS } from "../../src/constants/index.js";
+import { PERMA_API_BASE_URL } from "../../src/constants/index.js";
+
+let testFolder = null;
+
+test.beforeAll(async () => {
+  const api = new PermaAPI(process.env.TESTS_API_KEY, PERMA_API_BASE_URL);
+  const user = await api.pullUser();
+
+  if (process.env.TESTS_API_ALLOW_NON_TEST_USER !== "1" && user.full_name !== EXPECTED_TESTS_API_USER) {
+    throw new Error(
+      `TESTS_API_KEY belongs to "${user.full_name}", expected "${EXPECTED_TESTS_API_USER}". ` +
+      "Set TESTS_API_ALLOW_NON_TEST_USER=1 to intentionally run the live API tests with another account."
+    );
+  }
+
+  const topLevel = await api.pullTopLevelFolders(1);
+  const personalFolder = topLevel.objects[0];
+  testFolder = await api.createFolder(personalFolder.id, `perma-extension-e2e-${Date.now()}`);
+});
+
+test.afterAll(async () => {
+  if (testFolder === null) {
+    return;
+  }
+
+  const api = new PermaAPI(process.env.TESTS_API_KEY, PERMA_API_BASE_URL);
+  await api.deleteFolder(testFolder.id);
+});
 
 // Refresh extension page and wait `WAIT_MS_AFTER_BOOT` ms before each test.
 // Clears `chrome.storage.local` before each test.
@@ -17,6 +48,14 @@ test.beforeEach(async ({ page, extensionId }, testInfo) => {
   // Clear storage
   await page.evaluate(async () => await chrome.storage.local.clear());
   await page.reload();
+
+  // Simulate a real, capturable current tab. The folder cascade lives inside the create-archive
+  // form, which only renders for capturable pages; the test browser's active tab is the popup's own
+  // `chrome-extension://` page (non-capturable), so seed a real page via `TAB_SWITCH` first.
+  await page.evaluate(async (args) => {
+    const { MESSAGE_IDS, url, title } = args;
+    await chrome.runtime.sendMessage({ messageId: MESSAGE_IDS.TAB_SWITCH, url, title });
+  }, { MESSAGE_IDS, url: MOCK_TAB_URL, title: MOCK_TAB_TITLE });
 
   // Sign in
   await page.evaluate( async(apiKey) => {
@@ -29,33 +68,55 @@ test.beforeEach(async ({ page, extensionId }, testInfo) => {
 });
 
 test("App retains folder that user picked as a default", async ({ page, extensionId }) => {
-  // Ensure there is a subfolder within the test user's account; if not, we must create it manually
-  const foldersCount = await page.evaluate(async () => {
-    return document.querySelectorAll("select[name='folders-pick']").length;
-  })
-  expect(foldersCount, "user account contains subfolder required for test").toBeGreaterThan(0);
+  // The picker is a lazy cascade. The test user only needs Personal Links at the top level; this
+  // test creates a temporary child folder under it, then picks that child in the second select.
+  await page.waitForSelector("select.folders-pick[data-level='1']");
 
   const beforePick = await page.evaluate(async () => {
-    return document.querySelector("select[name='folders-pick']").value;
+    const { folders } = await chrome.storage.local.get("folders");
+    return folders.pick;
   });
 
   // Simulate picking another folder
-  await page.evaluate(async () => {
-    const picker = document.querySelector("select[name='folders-pick']");
-    picker.value = picker.options[picker.options.length - 1].value; // Pick last of list
+  const picked = await page.evaluate(async (folderId) => {
+    const picker = document.querySelector("select.folders-pick[data-level='1']");
+    const value = String(folderId);
+    picker.value = value;
     picker.dispatchEvent(new Event("change"));
-  });
+    return value;
+  }, testFolder.id);
+
+  // Wait for `FOLDERS_PICK_ONE` to actually persist the new selection before reloading. The change
+  // handler fires the message and returns immediately, so reloading right away can race the save and
+  // restore the previous pick (`folders.path[0]`).
+  await page.waitForFunction(
+    async (picked) => {
+      const { folders } = await chrome.storage.local.get("folders");
+      return String(folders?.pick) === String(picked);
+    },
+    picked
+  );
 
   // Reload page and check that value was kept
   await page.reload();
-  await page.waitForTimeout(WAIT_MS_AFTER_BOOT);
+
+  // Reloading re-runs `onPopupOpen`, which resets the current tab to the popup's own
+  // `chrome-extension://` page (non-capturable) — collapsing the create form and its cascade. Wait
+  // for that to settle, then re-seed a capturable tab so the cascade renders again from storage.
+  await page.waitForTimeout(WAIT_MS_AFTER_BOOT * 2);
+  await page.evaluate(async (args) => {
+    const { MESSAGE_IDS, url, title } = args;
+    await chrome.runtime.sendMessage({ messageId: MESSAGE_IDS.TAB_SWITCH, url, title });
+  }, { MESSAGE_IDS, url: MOCK_TAB_URL, title: MOCK_TAB_TITLE });
+  await page.waitForSelector("select.folders-pick[data-level='1']");
 
   const afterPick = await page.evaluate(async () => {
-    return document.querySelector("select[name='folders-pick']").value;
+    return document.querySelector("select.folders-pick[data-level='1']").value;
   });
 
   // Compare
   expect(beforePick).toBeDefined();
   expect(afterPick).toBeDefined();
-  expect(afterPick).not.toBe(beforePick);
+  expect(afterPick).toBe(String(testFolder.id));
+  expect(afterPick).not.toBe(String(beforePick));
 });

--- a/tests/scenarios/signIn.spec.js
+++ b/tests/scenarios/signIn.spec.js
@@ -7,7 +7,8 @@
  */
 import { expect } from "@playwright/test";
 import { test, WAIT_MS_AFTER_BOOT } from "../index.js";
-import { MOCK_API_KEY } from "../mocks.js";
+import { MOCK_API_KEY, MOCK_TAB_URL, MOCK_TAB_TITLE } from "../mocks.js";
+import { MESSAGE_IDS } from "../../src/constants/index.js";
 
 // Refresh extension page and wait `WAIT_MS_AFTER_BOOT` ms before each test.
 // Clears `chrome.storage.local` before each test.
@@ -16,6 +17,15 @@ test.beforeEach(async ({ page, extensionId }, testInfo) => {
   await page.evaluate(async () => await chrome.storage.local.clear());
   await page.reload();
   await page.waitForTimeout(WAIT_MS_AFTER_BOOT);
+
+  // Simulate a real, capturable current tab. In the test browser the active tab is the popup's own
+  // `chrome-extension://` page, which is non-capturable — so once signed in the archive form would
+  // render the "can't be archived" panel instead of the create-archive form. A real popup always
+  // opens over the page the user is on, so seed that here via `TAB_SWITCH`.
+  await page.evaluate(async (args) => {
+    const { MESSAGE_IDS, url, title } = args;
+    await chrome.runtime.sendMessage({ messageId: MESSAGE_IDS.TAB_SWITCH, url, title });
+  }, { MESSAGE_IDS, url: MOCK_TAB_URL, title: MOCK_TAB_TITLE });
 });
 
 test("App switches between Sign-In and Archive Creation when valid credentials are provided.", async ({ page, extensionId }) => {

--- a/tests/scenarios/signOut.spec.js
+++ b/tests/scenarios/signOut.spec.js
@@ -44,5 +44,8 @@ test("App switches back to the Sign-In form and clears user data from storage up
   expect(storage.auth.isChecked).toBe(false);
   expect(storage.auth.apiKey).toBe("");
   expect(Object.values(storage.archives.byUrl)).toHaveLength(0);
-  expect(Object.values(storage.folders.available)).toHaveLength(0);
+  // Folders are now a lazy cascade (`levels` / `path` / `pick`) rather than a flat `available` map.
+  expect(storage.folders.levels).toHaveLength(0);
+  expect(storage.folders.path).toHaveLength(0);
+  expect(storage.folders.pick).toBe(null);
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -94,11 +94,13 @@ export default defineConfig({
 
   plugins: [
     viteStaticCopy({
+      // vite-plugin-static-copy preserves the source directory structure in the
+      // output, so strip the leading `src/` segment to land files at the dist root.
       targets: [
-        {src: "src/manifest.json", dest: "", transform: transformManifest},
-        {src: "src/assets", dest: ""},
-        {src: "src/_locales", dest: ""},
-        {src: "src/popup/index.html", dest: "popup"},
+        {src: "src/manifest.json", dest: "", transform: transformManifest, rename: {stripBase: true}},
+        {src: "src/assets", dest: "", rename: {stripBase: 1}},
+        {src: "src/_locales", dest: "", rename: {stripBase: 1}},
+        {src: "src/popup/index.html", dest: "popup", rename: {stripBase: true}},
       ]
     }),
     popupCSSBundle()


### PR DESCRIPTION
I've been chasing down weird self-inflicted traffic patterns in Perma's logs to make it easier to interpret unexpected events.

One of those self-inflicted patterns is in the extension: while the popup is open, it (a) polls all of the user's links for the current page every five seconds; (b) recursively fetches all of the user's folders every 20 seconds. These can both look like abuse and the folder fetches are especially a flood.

In the course of tracking those down, I fixed up some other correctness issues with the extension's API use, and did some underlying housekeeping.

Changes:

* Housekeeping:
  * Bump dependencies
  * Add a justfile with build and dev commands, notably to launch a browser with the extension loaded via `just dev chrome` or `just dev firefox`. Tweak live-server tests (which point at real perma.cc!) to check that the API key belongs to our test user (can override with an env var).
  * Serialize writes to localstorage so there are no race conditions
  * Tag requests with Perma-Client: <version> so we can see traffic patterns more easily (RFC 6648 says X- prefixes are no longer recommended for custom headers)
* Major API efficiency updates:
  * Instead of a single dropdown with the user's entire folder tree that is refreshed every 20 seconds, browse folders as a "lazy cascade" (screenshot below): show a dropdown for the top level, and when a folder is selected, show a dropdown for the next level. This lets us only fetch folders when needed, avoiding the need for huge requests or caching, and avoiding one huge un-navigable dropdown for users with lots of folders. Removes lots of API calls every 20 seconds.
  * Instead of polling all links for the current url every 5 seconds (which existed to show progress on an active capture), fetch once when the popup loads. (Here I also removed an exact-match filter, so it just shows what the API delivers; Becky and I think that's more correct.) Then to show progress, use the same capture-jobs endpoint polling logic the Perma dashboard uses. This lets us show a progress bar under the active capture, and poll only while captures are active.
* Minor API cleanup:
  * Don't check if capture is complete before deleting, since we only show delete button for eligible archives (removes extra API call)
  * Don't sign out the user (deleting API key and local storage) when any 401 or 403 message is received from the API. Instead detect actual invalid-key responses and show a "key invalid, retry / update?" screen. (improves correctness)
  * On non-http or non-public-IP urls, don't offer to capture and fail, show a "page can't be captured" message. (improves correctness). I included perma.cc links in this list since we reject attempts to capture perma.cc/GUID links; I was going to show something cute there instead but that seems like too far down a side quest of a side quest.

<img width="359" height="531" alt="image" src="https://github.com/user-attachments/assets/e7d71db7-4d80-45c6-a2ab-ca9e8a967c8e" />
<img width="363" height="548" alt="image" src="https://github.com/user-attachments/assets/3930ff8b-7a19-4dcd-92f3-5462360afd05" />
<img width="363" height="547" alt="image" src="https://github.com/user-attachments/assets/cb4ec7bb-cae1-4b4b-a85c-2904cfb5ec45" />
